### PR TITLE
Tests for NSHMP grid XML file format

### DIFF
--- a/shakemap/utils/readwrite.py
+++ b/shakemap/utils/readwrite.py
@@ -76,10 +76,12 @@ def read_nshmp_fault_xml(file):
 
     return srclist
 
-def read_nshmp_rlme_xml(file):
+def read_nshmp_grid_xml(file):
     """
-    Method for reading the XML format used by the NSHMP for faults. 
+    Method for reading the XML format used by the NSHMP for gridded seismicity.  
     `[example] <https://github.com/usgs/nshmp-model-cous-2014/blob/master/Central%20%26%20Eastern%20US/Grid/rlme/Charlevoix%20Seismic%20Zone.xml>`__
+
+    This function works for both grided source, including RMLEs. 
 
     :param file:
         An XML file in the format used for the 2014 USGS NSHMP. 
@@ -88,7 +90,9 @@ def read_nshmp_rlme_xml(file):
         A dictionary with two entries: 'Settings' and 'Nodes'. 
         'Settings" is a dictionary, 'Nodes' is a list of dictionaries with
         length equal to the total number of RLME nodes. The Node dictionaries
-        include elements for 'lat', 'lon', 'dep', 'rate', etc. 
+        include elements for 'lat', 'lon', 'dep', 'rate', etc. Note that there
+        are minor differences in these values depending on whether or not the
+        gridded seismicity is for RLMEs or not. 
 
     """
 

--- a/tests/data/USGS_grid.xml
+++ b/tests/data/USGS_grid.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GridSourceSet id="-1" name="USGS Adaptive Smoothing Zone 4" weight="0.2">
+  <!-- This model is an example and for review purposes only -->
+  <!-- Original source file: CEUS_adaptGridded_2014_2zone.in -->
+  <Settings>
+    <DefaultMfds>
+      <IncrementalMfd a="0.0" b="1.0" dMag="0.1" mMax="6.45" mMin="4.75" type="GR" weight="0.2"/>
+      <IncrementalMfd a="0.0" b="1.0" dMag="0.1" mMax="6.95" mMin="4.75" type="GR" weight="0.5"/>
+      <IncrementalMfd a="0.0" b="1.0" dMag="0.1" mMax="7.45" mMin="4.75" type="GR" weight="0.2"/>
+      <IncrementalMfd a="0.0" b="1.0" dMag="0.1" mMax="7.95" mMin="4.75" type="GR" weight="0.1"/>
+    </DefaultMfds>
+    <SourceProperties focalMechMap="[STRIKE_SLIP:1.0,NORMAL:0.0,REVERSE:0.0]" magDepthMap="[10.0::[5.0:1.0]]" maxDepth="22.0" ruptureScaling="NSHM_SOMERVILLE" strike="NaN"/>
+  </Settings>
+  <Nodes>
+    <Node a="0.065168671" type="GR">-109.8,34.6,0.0</Node>
+    <Node a="0.066329032" type="GR">-109.7,34.6,0.0</Node>
+    <Node a="0.067413777" type="GR">-109.6,34.6,0.0</Node>
+    <Node a="0.068402007" type="GR">-109.5,34.6,0.0</Node>
+    <Node a="0.069273196" type="GR">-109.4,34.6,0.0</Node>
+    <Node a="0.070007674" type="GR">-109.3,34.6,0.0</Node>
+    <Node a="0.065272875" type="GR">-110.0,34.7,0.0</Node>
+    <Node a="0.066596664" type="GR">-109.9,34.7,0.0</Node>
+    <Node a="0.067880124" type="GR">-109.8,34.7,0.0</Node>
+    <Node a="0.069103561" type="GR">-109.7,34.7,0.0</Node>
+    <Node a="0.07024578" type="GR">-109.6,34.7,0.0</Node>
+    <Node a="0.071285263" type="GR">-109.5,34.7,0.0</Node>
+    <Node a="0.07220085" type="GR">-109.4,34.7,0.0</Node>
+    <Node a="0.27957186" type="GR">-110.7,39.5,0.0</Node>
+  </Nodes>
+</GridSourceSet>

--- a/tests/utils/readwrite_test.py
+++ b/tests/utils/readwrite_test.py
@@ -5,7 +5,7 @@ import os.path
 import numpy as np
 
 from shakemap.utils.readwrite import read_nshmp_fault_xml
-from shakemap.utils.readwrite import read_nshmp_rlme_xml
+from shakemap.utils.readwrite import read_nshmp_grid_xml
 
 homedir = os.path.dirname(os.path.abspath(__file__))
 shakedir = os.path.abspath(os.path.join(homedir, '../..'))
@@ -79,7 +79,7 @@ def test_read_nshmp_fault_xml():
 
 def test_read_nshmp_grid_xml():
     file = os.path.join(datdir, 'USGS_grid.xml')
-    sub = read_nshmp_rlme_xml(file)
+    sub = read_nshmp_grid_xml(file)
 
     # Test Settings
     mfds = sub['Settings']['DefaultMfds']
@@ -131,7 +131,7 @@ def test_read_nshmp_grid_xml():
 
 def test_read_nshmp_rlme_xml():
     file = os.path.join(datdir, 'Charlevoix Seismic Zone.xml')
-    sub = read_nshmp_rlme_xml(file)
+    sub = read_nshmp_grid_xml(file)
 
     # Test Settings
     mfds = sub['Settings']['DefaultMfds']

--- a/tests/utils/readwrite_test.py
+++ b/tests/utils/readwrite_test.py
@@ -77,6 +77,57 @@ def test_read_nshmp_fault_xml():
     assert sub[0]['IncrementalMfd'][2]['type'] == 'SINGLE'
     assert sub[0]['IncrementalMfd'][2]['weight'] == '0.333'
 
+def test_read_nshmp_grid_xml():
+    file = os.path.join(datdir, 'USGS_grid.xml')
+    sub = read_nshmp_rlme_xml(file)
+
+    # Test Settings
+    mfds = sub['Settings']['DefaultMfds']
+    srcp = sub['Settings']['SourceProperties']
+    assert [m['a'] for m in mfds] == ['0.0', '0.0', '0.0', '0.0']
+    assert [m['b'] for m in mfds] == ['1.0', '1.0', '1.0', '1.0']
+    assert [m['dMag'] for m in mfds] == ['0.1', '0.1', '0.1', '0.1']
+    assert [m['mMax'] for m in mfds] == ['6.45', '6.95', '7.45', '7.95']
+    assert [m['mMin'] for m in mfds] == ['4.75', '4.75', '4.75', '4.75']
+    assert [m['type'] for m in mfds] == ['GR', 'GR', 'GR', 'GR']
+    assert [m['weight'] for m in mfds] == ['0.2', '0.5', '0.2', '0.1']
+    assert srcp['focalMechMap'] == '[STRIKE_SLIP:1.0,NORMAL:0.0,REVERSE:0.0]'
+    assert srcp['magDepthMap'] == '[10.0::[5.0:1.0]]'
+    assert srcp['maxDepth'] == '22.0'
+    assert srcp['ruptureScaling'] == 'NSHM_SOMERVILLE'
+    assert srcp['strike'] == 'NaN'
+
+    # Test nodes
+    nodes = sub['Nodes']
+    z = np.array([n['dep'] for n in nodes])
+    ztarget = np.array(
+      [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.])
+    np.testing.assert_allclose(z, ztarget)
+
+    lat = np.array([n['lat'] for n in nodes])
+    lattarget = np.array(
+      [ 34.6,  34.6,  34.6,  34.6,  34.6,  34.6,  34.7,  34.7,  34.7,
+        34.7,  34.7,  34.7,  34.7,  39.5])
+    np.testing.assert_allclose(lat, lattarget)
+
+    lon = np.array([n['lon'] for n in nodes])
+    lontarget = np.array(
+      [-109.8, -109.7, -109.6, -109.5, -109.4, -109.3, -110. , -109.9,
+       -109.8, -109.7, -109.6, -109.5, -109.4, -110.7])
+    np.testing.assert_allclose(lon, lontarget)
+
+    a = np.array([float(n['a']) for n in nodes])
+    atarget = np.array(
+      [ 0.06516867,  0.06632903,  0.06741378,  0.06840201,  0.0692732 ,
+        0.07000767,  0.06527287,  0.06659666,  0.06788012,  0.06910356,
+        0.07024578,  0.07128526,  0.07220085,  0.27957186])
+    np.testing.assert_allclose(lon, lontarget)
+
+    t = np.array([n['type'] for n in nodes])
+    ttarget = ['GR', 'GR', 'GR', 'GR', 'GR', 'GR', 'GR', 'GR', 'GR', 'GR', 'GR',
+       'GR', 'GR', 'GR']
+    assert all(t == ttarget)
+
 
 def test_read_nshmp_rlme_xml():
     file = os.path.join(datdir, 'Charlevoix Seismic Zone.xml')
@@ -96,7 +147,7 @@ def test_read_nshmp_rlme_xml():
     assert srcp['ruptureScaling'] == 'NSHM_POINT_WC94_LENGTH'
     assert srcp['strike'] == 'NaN'
 
-    # Test Notes
+    # Test Nodes
     nodes = sub['Nodes']
     z = np.array([n['dep'] for n in nodes])
     ztarget = np.array(


### PR DESCRIPTION
It turns out that the file format for grid files is essentially the same as rlmes. There is some minor differences inside the Settings tag, but the rlme code I wrote before is general enough to handle these. So I just added new tests for grid xml files. closes #229 closes #228 