### PR TITLE
Fixes to read and fix old shakemap fault files

### DIFF
--- a/shakelib/rupture/factory.py
+++ b/shakelib/rupture/factory.py
@@ -88,9 +88,12 @@ def rupture_from_dict_and_origin(rupdict, origin, mesh_dx=0.5):
     .. seealso:: :func:`rupture_from_dict`
 
     Args:
-        rupdictd (dict): Rupture GeoJSON dictionary.
-        origin (Origin): A ShakeMap origin object.
-        mesh_dx (float): Target spacing (in km) for rupture discretization;
+        rupdictd (dict):
+            Rupture GeoJSON dictionary.
+        origin (Origin):
+            A ShakeMap origin object.
+        mesh_dx (float):
+            Target spacing (in km) for rupture discretization;
             default is 0.5 km and it is only used if the rupture file is an
             EdgeRupture.
 
@@ -123,7 +126,8 @@ def rupture_from_dict(d):
         :func:`rupture_from_dict_and_origin`
 
     Args:
-        d (dict): Rupture GeoJSON dictionary, which must contain origin
+        d (dict):
+            Rupture GeoJSON dictionary, which must contain origin
             information in the 'metadata' field.
 
     Returns:
@@ -151,42 +155,91 @@ def rupture_from_dict(d):
     return rupt
 
 
-def _check_polygon(polygon, new_format):
-    xyz = np.array(polygon)
-    if not new_format:
-        # switch from lat/lon/z to lon/lat/z
-        tmp = xyz[:, 0].copy()
-        xyz[:, 0] = xyz[:, 1].copy()
-        xyz[:, 1] = tmp.copy()
+def _rotate_polygon(p):
+    """
+    This is a method to rotate a polygon, which is used to try to
+    fix incorrectly specified polygons.
 
-    # ensure the polygon is closed
-    if not np.array_equal(xyz[-1, :], xyz[0, :]):
-        raise ShakeLibException(
-            'Rupture file %s has unclosed segments.' % file)
+    Args:
+        p (list):
+            A list of lon/lat/depth lists.
 
-    # ensure the polygon is specified top-edge first
-    if xyz[1, 2] > xyz[-2, 2]:  # does this file specify bottom edge first?
-        if new_format:
-            raise ShakeLibException(
-                'Rupture file %s must be specified top-edge first.' % file)
-        # drop last point
-        xyz = xyz[0:-1, :]
-        # reverse order of points
-        xyz = np.flipud(xyz)
-        # put new first point onto the end so that it is closed.
-        xyz = np.append(xyz, np.reshape(xyz[0, :], (1, 3)), axis=0)
+    Returns:
+        list: Same as before but the points have been incremented
+        by one in position.
 
-    # turn numpy back into list of x,y,z sequences
-    polygon = xyz.tolist()
+    """
+    # Convert to numpy array for better indexing support
+    parray = np.array(p)
+
+    # Ensure the polygon is closed
+    if not np.array_equal(parray[-1, :], parray[0, :]):
+        raise ShakeLibException('Rupture file has unclosed segments.')
+
+    # Drop last point
+    parray = parray[0:-1, :]
+
+    # Rotate by putting first at end
+    parray = np.append(parray[1:, :],
+                       np.reshape(parray[0, :], (1, -1)),
+                       axis=0)
+
+    # Put new first point onto the end so that it is closed.
+    parray = np.append(parray,
+                       np.reshape(parray[0, :], (1, -1)),
+                       axis=0)
+
+    # Turn numpy array back into a list
+    polygon = parray.tolist()
     return polygon
+
+
+def _check_polygon(p):
+    """
+    Check if the verticies are specified top first.
+
+    Args:
+        p (list):
+            A list of five lon/lat/depth lists.
+
+    Raises:
+        Exception: Incorrectly specified polygon.
+
+    """
+    n_points = len(p)
+    if n_points % 2 == 0:
+        raise Exception('Number of points in polyon must be odd.')
+
+    if p[0] != p[-1]:
+        raise Exception('First and last points in polygon must be '
+                        'identical.')
+
+    n_pairs = int((n_points - 1) / 2)
+    for j in range(n_pairs):
+        # -------------------------------------------------------------
+        # Points are paired and in each pair the top is first, as in:
+        #
+        #      _.-P1-._
+        #   P0'        'P2---P3
+        #   |                  \
+        #   P7---P6----P5-------P4
+        #
+        # Pairs: P0-P7, P1-P6, P2-P5, P3-P4
+        # -------------------------------------------------------------
+        top_depth = p[j][2]
+        bot_depth = p[-(j + 2)][2]
+        if top_depth >= bot_depth:
+            raise Exception(
+                'Top points must be ordered before bottom points.')
 
 
 def text_to_json(file, new_format=True):
     """
-    Read in old or new ShakeMap 3 textfile rupture format and convert to GeoJSON.
+    Read in old or new ShakeMap 3 textfile rupture format and convert to
+    GeoJSON.
 
-    This will handle ShakeMap3.5-style fault text files, which can have the following
-    format:
+    This will handle ShakeMap3.5-style fault text files, which can have the
+    following format:
      - # at the top indicates a reference.
      - Lines beginning with a > indicate the end of one segment and the
        beginning of another.
@@ -195,18 +248,21 @@ def text_to_json(file, new_format=True):
      - Vertices can be specified in top-edge or bottom-edge first order.
 
     Args:
-        rupturefile (str): Path to rupture file OR file-like object in GMT
+        rupturefile (str):
+            Path to rupture file OR file-like object in GMT
             psxy format, where:
 
-                * Rupture vertices are space/comma separated lat, lon, depth triplets
-                  on a single line.
+                * Rupture vertices are space/comma separated lat, lon, depth
+                  triplets on a single line.
                 * Rupture groups are separated by lines containing ">"
                 * Rupture groups must be closed.
                 * Verticies within a rupture group must start along the top
                   edge and move in the strike direction then move to the bottom
                   edge and move back in the opposite direction.
-        new_format (bool): Indicates whether text rupture format is
-            "old" or "new" style.
+
+        new_format (bool):
+            Indicates whether text rupture format is
+            "old" (lat, lon, depth) or "new" (lon, lat, depth) style.
 
     Returns:
         dict: GeoJSON rupture dictionary.
@@ -225,16 +281,19 @@ def text_to_json(file, new_format=True):
     for line in f.readlines():
         if not len(line.strip()):
             continue
+
         if line.strip().startswith('#'):
+            # Get reference string
             reference += line.strip().replace('#', '')
             continue
+
         if line.strip().startswith('>'):
             if not len(polygon):
                 continue
-            polygon = _check_polygon(polygon, new_format)
             polygons.append(polygon)
             polygon = []
             continue
+
         # first try to split on whitespace
         parts = line.split()
         if len(parts) == 1:
@@ -245,18 +304,37 @@ def text_to_json(file, new_format=True):
             if len(parts) == 1:
                 raise ShakeLibException(
                     'Rupture file %s has unspecified delimiters.' % file)
+
         if len(parts) != 3:
             msg = 'Rupture file %s is not in lat,lon,depth format.'
             if new_format:
                 'Rupture file %s is not in lon,lat,depth format.'
             raise ShakeLibException(msg % file)
+
         parts = [float(p) for p in parts]
+        if not new_format:
+            old_parts = parts.copy()
+            parts[0] = old_parts[1]
+            parts[1] = old_parts[0]
         polygon.append(parts)
+
     if len(polygon):
-        polygon = _check_polygon(polygon, new_format)
         polygons.append(polygon)
+
     if isfile:
         f.close()
+
+    # Try to fix polygons
+    n_polygons = len(polygons)
+    for i in range(n_polygons):
+        valid_polygon = False
+        while valid_polygon is False:
+            try:
+                _check_polygon(polygons[i])
+                valid_polygon = True
+            except:
+                polygons[i] = _rotate_polygon(polygons[i])
+
     json_dict = {
         "type": "FeatureCollection",
         "metadata": {
@@ -275,107 +353,9 @@ def text_to_json(file, new_format=True):
             }
         ]
     }
+    validate_json(json_dict)
+
     return json_dict
-
-
-# def text_to_json(file):
-#     """
-#     Read in textfile rupture format and convert to GeoJSON.
-
-#     Args:
-#         rupturefile (srt): Path to rupture file OR file-like object in GMT
-#             psxy format, where:
-
-#                 * Rupture vertices are space separated lon, lat, depth triplets
-#                   on a single line.
-#                 * Rupture groups are separated by lines containing ">"
-#                 * Rupture groups must be closed.
-#                 * Vertices within a rupture group must start along the top
-#                   edge and move in the strike direction then move to the bottom
-#                   edge and move back in the opposite direction.
-
-#     Returns:
-#         dict: GeoJSON rupture dictionary.
-
-#     """
-#     msg = '''In ShakeMap 4.0, the order of coordinates in fault.txt files
-# has changed from lat,lon,depth to lon, lat, depth.  If you have specified
-# your vertices in the older-style, your results will likely not be what you
-# expected.'''
-#     logging.warn(msg)
-#     # -------------------------------------------------------------------------
-#     # First read in the data
-#     # -------------------------------------------------------------------------
-#     x = []
-#     y = []
-#     z = []
-#     isFile = False
-#     if isinstance(file, str):
-#         isFile = True
-#         file = open(file, 'rt')
-#         lines = file.readlines()
-#     else:
-#         lines = file.readlines()
-#     reference = ''
-#     for line in lines:
-#         sline = line.strip()
-#         if sline.startswith('#'):
-#             reference += sline
-#             continue
-#         if sline.startswith('>'):
-#             if len(x):  # start of new line segment
-#                 x.append(np.nan)
-#                 y.append(np.nan)
-#                 z.append(np.nan)
-#                 continue
-#             else:  # start of file
-#                 continue
-#         if not len(sline.strip()):
-#             continue
-#         parts = sline.split()
-#         if len(parts) < 3:
-#             parts = sline.split(',')
-#             if len(parts) < 3:
-#                 raise ShakeLibException(
-#                     'Rupture file %s has no depth values.' % file)
-#         y.append(float(parts[0]))
-#         x.append(float(parts[1]))
-#         z.append(float(parts[2]))
-#     if isFile:
-#         file.close()
-
-#     # Construct GeoJSON dictionary
-
-#     coords = []
-#     poly = []
-#     for lon, lat, dep in zip(x, y, z):
-#         if np.isnan(lon):
-#             coords.append(poly)
-#             poly = []
-#         else:
-#             poly.append([lon, lat, dep])
-#     if poly != []:
-#         coords.append(poly)
-
-#     d = {
-#         "type": "FeatureCollection",
-#         "metadata": {
-#             'reference': reference
-#         },
-#         "features": [
-#             {
-#                 "type": "Feature",
-#                 "properties": {
-#                     "rupture type": "rupture extent"
-#                 },
-#                 "geometry": {
-#                     "type": "MultiPolygon",
-#                     "coordinates": [coords]
-#                 }
-#             }
-#         ]
-#     }
-#     return d
 
 
 def validate_json(d):
@@ -417,32 +397,7 @@ def validate_json(d):
     if geom['type'] == 'MultiPolygon':
         n_polygons = len(polygons)
         for i in range(n_polygons):
-            p = polygons[i]
-            n_points = len(p)
-            if n_points % 2 == 0:
-                raise Exception('Number of points in polyon must be odd.')
-
-            if p[0] != p[-1]:
-                raise Exception('First and last points in polygon must be '
-                                'identical.')
-
-            n_pairs = int((n_points - 1) / 2)
-            for j in range(n_pairs):
-                # -------------------------------------------------------------
-                # Points are paired and in each pair the top is first, as in:
-                #
-                #      _.-P1-._
-                #   P0'        'P2---P3
-                #   |                  \
-                #   P7---P6----P5-------P4
-                #
-                # Pairs: P0-P7, P1-P6, P2-P5, P3-P4
-                # -------------------------------------------------------------
-                top_depth = p[j][2]
-                bot_depth = p[-(j + 2)][2]
-                if top_depth >= bot_depth:
-                    raise Exception(
-                        'Top points must be ordered before bottom points.')
+            _check_polygon(polygons[i])
 
 
 def is_quadrupture_class(d):

--- a/shakelib/rupture/factory.py
+++ b/shakelib/rupture/factory.py
@@ -325,15 +325,26 @@ def text_to_json(file, new_format=True):
         f.close()
 
     # Try to fix polygons
+    original_polygons = polygons.copy()
+    fixed = []
     n_polygons = len(polygons)
     for i in range(n_polygons):
-        valid_polygon = False
-        while valid_polygon is False:
+        n_verts = len(polygons[i])
+        success = False
+        for j in range(n_verts - 1):
             try:
                 _check_polygon(polygons[i])
-                valid_polygon = True
+                success = True
+                continue
             except:
                 polygons[i] = _rotate_polygon(polygons[i])
+        if success:
+            fixed.append(True)
+        else:
+            fixed.append(False)
+
+    if not all(fixed):
+        polygons = original_polygons
 
     json_dict = {
         "type": "FeatureCollection",

--- a/tests/shakelib/rupture_test.py
+++ b/tests/shakelib/rupture_test.py
@@ -9,7 +9,6 @@ import copy
 import tempfile
 import shutil
 import time
-import json
 
 # third party
 import numpy as np
@@ -28,7 +27,6 @@ from shakelib.rupture.factory import rupture_from_dict
 
 from shakelib.rupture.utils import get_local_unit_slip_vector
 from shakelib.rupture.utils import get_quad_slip
-from shakelib.rupture.factory import text_to_json
 from impactutils.time.ancient_time import HistoricTime
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
@@ -73,10 +71,16 @@ def test_text_to_json():
 N. Ratchkovski, and R. Hansen (2004). Inverse kinematic and forward dynamic
 models of the 2002 Denali fault earthquake, Alaska, Bull. Seism. Soc. Am. 94, S214-S233.'''
     assert jdict['metadata']['reference'] == refcmp.replace('\n', ' ')
-    cstart = [[-147.807, 63.434, 0.0], [-147.21, 63.472, 0.0], [-147.267,
-                                                                63.65, 22.294], [-147.864, 63.613, 22.294], [-147.807, 63.434, 0.0]]
-    cend = [[-142.5, 62.114, 0.0], [-143.669, 62.831, 0.0], [-143.669,
-                                                             62.831, 30.0], [-142.5, 62.114, 30.0], [-142.5, 62.114, 0.0]]
+    cstart = [[-147.807, 63.434, 0.0],
+              [-147.21,  63.472, 0.0],
+              [-147.267, 63.65,  22.294],
+              [-147.864, 63.613, 22.294],
+              [-147.807, 63.434, 0.0]]
+    cend = [[-142.5,   62.114, 0.0],
+            [-143.669, 62.831, 0.0],
+            [-143.669, 62.831, 30.0],
+            [-142.5,   62.114, 30.0],
+            [-142.5,   62.114, 0.0]]
 
     assert len(jdict['features'][0]['geometry']['coordinates'][0]) == 5
     assert jdict['features'][0]['geometry']['coordinates'][0][0] == cstart
@@ -100,8 +104,21 @@ models of the 2002 Denali fault earthquake, Alaska, Bull. Seism. Soc. Am. 94, S2
 12.0 93.5 40.0'''
     stringio = io.StringIO(sm_data2)
     jdict = text_to_json(stringio, new_format=False)
-    coords = [[93.5, 12.0, 40.0], [93.5, 12.0, 40.0], [94.2, 12.0, 40.0], [94.2, 10.0, 40.0], [95.0, 8.0, 40.0], [95.2, 7.0, 40.0], [95.78, 6.0, 40.0], [
-        94.45, 5.0, 10.0], [94.0, 2.98, 10.0], [93.5, 3.3, 10.0], [93.2, 5.0, 10.0], [93.1, 6.0, 10.0], [92.5, 7.0, 10.0], [92.5, 8.0, 10.0], [93.5, 10.0, 40.0]]
+    coords = [[93.5, 12.0,  40.0],
+              [93.5, 12.0,  40.0],
+              [94.2, 12.0,  40.0],
+              [94.2, 10.0,  40.0],
+              [95.0,  8.0,  40.0],
+              [95.2,  7.0,  40.0],
+              [95.78, 6.0,  40.0],
+              [94.45, 5.0,  10.0],
+              [94.0,  2.98, 10.0],
+              [93.5,  3.3,  10.0],
+              [93.2,  5.0,  10.0],
+              [93.1,  6.0,  10.0],
+              [92.5,  7.0,  10.0],
+              [92.5,  8.0,  10.0],
+              [93.5, 10.0,  40.0]]
     # assert len(jdict['features'][0]['geometry']['coordinates']) == 1
     # assert jdict['features'][0]['geometry']['coordinates'][0] == coords
 


### PR DESCRIPTION
I checked these changes with problematic faults (Sumatra and Maule), which were both specified incorrectly in different ways. This new method seems to fix both in a stable manner. Closes  #502 and closes #530. 