### PR TITLE
Set min/max values in child classes

### DIFF
--- a/shakelib/gmice/ak07.py
+++ b/shakelib/gmice/ak07.py
@@ -41,6 +41,7 @@ class AK07(GMICE):
     # -----------------------------------------------------------------------
     def __init__(self):
         super().__init__()
+        self.min_max = (1.0, 10.0)
         self.name = 'Atkinson and Kaka (2007)'
         self.scale = 'scale_ak07.ps'
         self._constants = {

--- a/shakelib/gmice/gmice.py
+++ b/shakelib/gmice/gmice.py
@@ -22,15 +22,14 @@ class GMICE(ABC):
     def getDistanceType():
         return 'rrup'
 
-    @staticmethod
-    def getMinMax():
+    def getMinMax(self):
         """
         Get the minimum and maximum MMI values produced by this GMICE.
 
         Returns:
             Tuple of min and max values of GMICE.
         """
-        return (1.0, 10.0)
+        return self.min_max
 
     def getName(self):
         """

--- a/shakelib/gmice/wald99.py
+++ b/shakelib/gmice/wald99.py
@@ -31,6 +31,7 @@ class Wald99(GMICE):
     # -----------------------------------------------------------------------
     def __init__(self):
         super().__init__()
+        self.min_max = (1.0, 10.0)
         self.name = 'Wald et al. (1999)'
         self.scale = 'scale_wald99.ps'
         self.__constants = {

--- a/shakelib/gmice/wgrw12.py
+++ b/shakelib/gmice/wgrw12.py
@@ -38,6 +38,7 @@ class WGRW12(GMICE):
     # -----------------------------------------------------------------------
     def __init__(self):
         super().__init__()
+        self.min_max = (1.0, 10.0)
         self.name = 'Worden et al. (2012)'
         self.scale = 'scale_wgrw12.ps'
         self._constants = {


### PR DESCRIPTION
This leaves the getMinMax module in the base class, but sets the values within the child classes.