### PR TITLE
Refactor conversions

### DIFF
--- a/shakelib/conversions/convert_imc.py
+++ b/shakelib/conversions/convert_imc.py
@@ -1,44 +1,162 @@
-from openquake.hazardlib import const
+# Standard library imports
+from abc import ABC, abstractmethod
 
 
-class ComponentConverter(object):
+class ComponentConverter(ABC):
     """Base class for implementing conversions between components."""
-    def __init__(self, imc_in, imc_out):
-        self.imc_in = imc_in
-        self.imc_out = imc_out
-        graph = {'Average Horizontal (RotD50)': set([
-                'Average Horizontal (GMRotI50)',
-                'Average horizontal',
-                'Horizontal Maximum Direction (RotD100)',
-                'Greater of two horizontal']),
-         'Average Horizontal (GMRotI50)': set([
-                'Average Horizontal (RotD50)',
-                'Greater of two horizontal']),
-         'Average horizontal': set([
-                'Average Horizontal (RotD50)',
-                'Greater of two horizontal']),
-         'Horizontal Maximum Direction (RotD100)': set([
-                'Average Horizontal (RotD50)',
-                'Greater of two horizontal']),
-         'Greater of two horizontal': set([
-                'Average Horizontal (RotD50)',
-                'Average Horizontal (GMRotI50)',
-                'Average horizontal',
-                'Horizontal Maximum Direction (RotD100)'])}
-        self.path = self.getShortestPath(graph, imc_in, imc_out)
 
-    def getShortestPath(self, graph, start, goal):
-        try:
-            return next(self.bfs_paths(graph, start, goal))
-        except StopIteration:
-            return None
+    def convertAmps(self, imt, amps, rrups=None, mag=None):
+        """
+        Return an array of amps converted from one IMC to another.
 
-    def bfs_paths(self, graph, start, goal):
-        queue = [(start, [start])]
+        Note: This can be used to perform chained conversions.
+
+        Args:
+            imt (OpenQuake IMT): The intensity measure type of the input
+                ground motions. Valid IMTs are PGA, PGV, and SA.
+            amps (array): A numpy array of the (logged) ground motions
+                to be converted.
+            rrups (array): A numpy array of the same shape as amps,
+                containing the rupture distances of the ground motions.
+                Default is None.
+            mag (float): The earthquake magnitude. Default is None.
+
+        Returns:
+            array: A numpy array of converted ground motions.
+        """
+        for idx, path in enumerate(self.path):
+            if idx != len(self.path) - 1:
+                self.imc_in = path
+                self.imc_out = self.path[idx + 1]
+                amps = self.convertAmpsOnce(imt, amps, rrups, mag)
+        return amps
+
+    @abstractmethod
+    def convertAmpsOnce(self, imt, amps, rrups, mag):
+        """
+        Return an array of amps converted from one IMC to another.
+
+        Note: This does not implement chained conversions.
+
+        Args:
+            imt (OpenQuake IMT): The intensity measure type of the input
+                ground motions. Valid IMTs are PGA, PGV, and SA.
+            amps (array): A numpy array of the (logged) ground motions
+                to be converted.
+            rrups (array): A numpy array of the same shape as amps,
+                containing the rupture distances of the ground motions.
+            mag (float): The earthquake magnitude.
+
+        Returns:
+            array: A numpy array of converted ground motions.
+        """
+        pass
+
+    def convertSigmas(self, imt, sigmas):
+        """
+        Return an array of standard deviations converted from one IMC
+        to another.
+
+        Note:  This can be used to perform chained conversions.
+
+        Args:
+            imt (OpenQuake IMT): The intensity measure type of the input
+                ground motions. Valid IMTs are PGA, PGV, and SA.
+            sigmas (array): A numpy array of the standard deviations of
+                the logged ground motions.
+
+        Returns:
+            array: A numpy array of converted standard deviations.
+        """
+        for idx, path in enumerate(self.path):
+            if idx != len(self.path) - 1:
+                self.imc_in = path
+                self.imc_out = self.path[idx + 1]
+                sigmas = self.convertSigmasOnce(imt, sigmas)
+        return sigmas
+
+    @abstractmethod
+    def convertSigmasOnce(self, imt, sigmas):
+        """
+        Return an array of standard deviations converted from one IMC
+        to another.
+
+        Note: This does not implement chained conversions.
+
+        Args:
+            imt (OpenQuake IMT): The intensity measure type of the input
+                ground motions. Valid IMTs are PGA, PGV, and SA.
+            sigmas (array): A numpy array of the standard deviations of
+                the logged ground motions.
+
+        Returns:
+            array: A numpy array of converted standard deviations.
+        """
+        pass
+
+    @staticmethod
+    def pathSearch(graph, imc_in, imc_out):
+        """
+        Helper method to create a "path" to convert one IMC to another.
+
+        This can be used for chain conversions
+
+        Args:
+            graph (Dictionary): Dictionary of sets describing possible
+                conversions between IMCs.
+            imc_in (IMC): OpenQuake IMC type of the input amp array.
+            imc_out (IMC): Desired OpenQuake IMC type of the output amps.
+
+        Returns:
+            list: IMCs as a path for to convert one IMC to another.
+        """
+        queue = [(imc_in, [imc_in])]
         while queue:
-            (vertex, path) = queue.pop(0)
-            for next in graph[vertex] - set(path):
-                if next == goal:
-                    yield path + [next]
+            (key, path) = queue.pop(0)
+            for next_path in graph[key] - set(path):
+                if next_path == imc_out:
+                    yield path + [next_path]
                 else:
-                    queue.append((next, path + [next]))
+                    queue.append((next_path, path + [next_path]))
+
+    def getShortestPath(self, graph, imc_in, imc_out):
+        """
+        Create a "path" to convert one IMC to another.
+
+        This can be used for chain conversions
+
+        Args:
+            graph (Dictionary): Dictionary of sets describing possible
+                conversions between IMCs.
+            imc_in (IMC): OpenQuake IMC type of the input amp array.
+            imc_out (IMC): Desired OpenQuake IMC type of the output amps.
+
+        Returns:
+            list: IMCs as a path for to convert one IMC to another.
+
+        Raises:
+            ValueError if no path is found.
+        """
+        try:
+            return next(self.pathSearch(graph, imc_in, imc_out))
+        except StopIteration:
+            if imc_in == imc_out:
+                return [imc_in, imc_out]
+            else:
+                raise ValueError('No possible conversion between %r and %r.' %
+                (imc_in, imc_out))
+
+    @abstractmethod
+    def _verifyConversion(self, imc_in, imc_out=None):
+        """
+        Helper method to ensure that the conversion is possible.
+
+        Args:
+            imc_in (IMC): OpenQuake IMC type of the input amp array.
+            imc_out (IMC): Desired OpenQuake IMC type of the output amps.
+                Default is None.
+
+        Raises:
+            ValueError if imc_in or imc_out are not valid..
+        """
+        pass

--- a/shakelib/conversions/convert_imc.py
+++ b/shakelib/conversions/convert_imc.py
@@ -1,0 +1,44 @@
+from openquake.hazardlib import const
+
+
+class ComponentConverter(object):
+    """Base class for implementing conversions between components."""
+    def __init__(self, imc_in, imc_out):
+        self.imc_in = imc_in
+        self.imc_out = imc_out
+        graph = {'Average Horizontal (RotD50)': set([
+                'Average Horizontal (GMRotI50)',
+                'Average horizontal',
+                'Horizontal Maximum Direction (RotD100)',
+                'Greater of two horizontal']),
+         'Average Horizontal (GMRotI50)': set([
+                'Average Horizontal (RotD50)',
+                'Greater of two horizontal']),
+         'Average horizontal': set([
+                'Average Horizontal (RotD50)',
+                'Greater of two horizontal']),
+         'Horizontal Maximum Direction (RotD100)': set([
+                'Average Horizontal (RotD50)',
+                'Greater of two horizontal']),
+         'Greater of two horizontal': set([
+                'Average Horizontal (RotD50)',
+                'Average Horizontal (GMRotI50)',
+                'Average horizontal',
+                'Horizontal Maximum Direction (RotD100)'])}
+        self.path = self.getShortestPath(graph, imc_in, imc_out)
+
+    def getShortestPath(self, graph, start, goal):
+        try:
+            return next(self.bfs_paths(graph, start, goal))
+        except StopIteration:
+            return None
+
+    def bfs_paths(self, graph, start, goal):
+        queue = [(start, [start])]
+        while queue:
+            (vertex, path) = queue.pop(0)
+            for next in graph[vertex] - set(path):
+                if next == goal:
+                    yield path + [next]
+                else:
+                    queue.append((next, path + [next]))

--- a/shakelib/multigmpe.py
+++ b/shakelib/multigmpe.py
@@ -163,7 +163,7 @@ class MultiGMPE(GMPE):
             for j in range(len(lnsd2)):
                 if stddev_types[j] == const.StdDev.INTER_EVENT:
                     continue
-                lsd[j] = bk17.convertStddevs(imt, lsd[j], dists.rrup, rup.mag)
+                lsd[j] = bk17.convertSigmas(imt, lsd[j])
 
             # -----------------------------------------------------------------
             # Compute weighted mean and sd

--- a/tests/shakelib/conversions/imc/beyer_bommer_2006_test.py
+++ b/tests/shakelib/conversions/imc/beyer_bommer_2006_test.py
@@ -162,19 +162,34 @@ def test_bb06():
     sigs_out = np.empty([0, 6])
     for imt in imt_in:
         for i in range(len(imc_in)):
-            bb06 = BeyerBommer2006()
-            tmp = bb06.ampIMCtoIMC(amps_in, imc_in[i], imc_out[i], imt)
+            bb06 = BeyerBommer2006(imc_in[i], imc_out[i])
+            tmp = bb06.convertAmps(imt, amps_in)
             amps_out = np.vstack((amps_out, tmp))
-            tmp = bb06.sigmaIMCtoIMC(sigmas_in, imc_in[i], imc_out[i], imt)
+            tmp = bb06.convertSigmas(imt, sigmas_in)
             sigs_out = np.vstack((sigs_out, tmp))
     np.testing.assert_allclose(amps_out, amps_target, atol=1e-5)
     np.testing.assert_allclose(sigs_out, sigs_target, atol=1e-5)
+
+    # Test that an invalid parameter raises an exception
     with pytest.raises(Exception) as a:
-        tmp = bb06.ampIMCtoIMC(amps_in, imc_in[0], 'a', imt_in[0])
+        bb06 = BeyerBommer2006('wrong', imc_out[0])
+        tmp = bb06.convertAmps(imt_in[0], amps_in)
     with pytest.raises(Exception) as a:
-        tmp = bb06.ampIMCtoIMC(amps_in, 'a', imc_out[0], imt_in[0])
-    with pytest.raises(Exception) as a:  # noqa
-        tmp = bb06.ampIMCtoIMC(amps_in, imc_in[0], imc_out[0], 'a')
+        bb06 = BeyerBommer2006(imc_out[0], 'wrong')
+        tmp = bb06.convertAmps(imt_in[0], amps_in)
+    with pytest.raises(Exception) as a:
+        bb06 = BeyerBommer2006(imc_in[0], imc_out[0])
+        tmp = bb06.convertAmps(imt_in[0], 'wrong')
+
+    # Test that the correct input/output imc returns the right path
+    bb06 = BeyerBommer2006('Median horizontal', 'Random horizontal')
+    assert len(bb06.path) == 2
+    assert bb06.path[0] == 'Median horizontal'
+    assert bb06.path[-1] == 'Random horizontal'
+    bb06 = BeyerBommer2006('Average Horizontal (RotD50)', 'Horizontal')
+    assert len(bb06.path) == 2
+    assert bb06.path[0] == 'Average Horizontal (RotD50)'
+    assert bb06.path[-1] == 'Horizontal'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Conversion classes were refactored to inherit from a base class (ComponentConverter). The base class includes all methods utilized for chained conversions. These were based upon the [breadth first search algorithm](https://eddmann.com/posts/depth-first-search-and-breadth-first-search-in-python/). Child classes must contain a "one step" conversion method for both standard deviations and amplitudes called `convertSigmasOnce` and `convertAmpsOnce` respectively. These will be called by `convertSigmas` and `convertAmps` within the base class for chained conversions. Child classes must also implement a helper method to test that each conversion is possible (`_verifyConversion`). 

**Conversions for BooreKishida2017:**
Average Horizontal (RotD50) and Greater of two horizontal be converted to any other component:
![screen shot 2018-05-17 at 9 08 22 am](https://user-images.githubusercontent.com/26904055/40186263-e2cdb5e0-59b1-11e8-9212-85ba9e327118.png)


**Conversions for BeyerBommer2006:**
All of the following components can be converted to one another:
- Average horizontal
- Greater of two horizontal
- Median horizontal
- Average Horizontal (GMRotI50)
- Average Horizontal (RotD50)
- Random horizontal
- Horizontal


TODO: Update documentation