### PR TITLE
Refactor imt classes to inherit from a base class.

### DIFF
--- a/shakelib/conversions/convert_imt.py
+++ b/shakelib/conversions/convert_imt.py
@@ -1,0 +1,76 @@
+# Standard library imports
+from abc import ABC, abstractmethod
+
+class TypeConverter(ABC):
+    """Base class for implementing conversions between intensity
+    measurement types (IMT)."""
+
+    @abstractmethod
+    def convertAmps(self, imt_in, imt_out, imt):
+        """
+        Returns an array of converted IMT amplitude values.
+
+        Args:
+            imt_in (str): OQ intensity measure type. Same as type as the input
+                values defined by the imt variable.
+            imt_out (str): OQ intensity measure type that the values will
+                be converted to.
+            imt (OpenQuake IMT): The intensity measure type of the input
+                ground motions. Valid IMTs are PGV, and SA.
+
+        Returns:
+            array: Numpy array of amps converted from imt_in to imt_out.
+
+        Raises:
+            ValueError: If not a valid conversion.
+        """
+        pass
+
+    def getConversionFactor(self):
+        """
+        Helper method that returns the conversion factor.
+
+        Returns:
+            float: Conversion factor.
+        """
+        factor = self.conversion_factor
+        return factor
+
+    def getInputIMT(self, imt_out):
+        """
+        Get valid input IMT types that can be converted to the specified imt_out.
+
+        Args:
+            imt (str): OQ intensity measure type.
+
+        Returns:
+            list: List of valid input IMT types. If not available types
+                None is returned.
+        """
+        imt_out = imt_out.upper().strip()
+        try:
+            imt_in = self.output_input[imt_out]
+            return imt_in
+        except KeyError:
+            print('No available conversion to %r' % imt_out)
+            return None
+
+    def _verifyConversion(self, imt_in, imt_out):
+        """
+        Helper method used to verify that a conversion is valid.
+
+        Args:
+            imt_in (str): OQ intensity measure type. Same as type as the input
+                values defined by the imt variable.
+            imt_out (str): OQ intensity measure type that the values will
+                be converted to.
+
+        Raises:
+            ValueError: If the conversion is not valid.
+        """
+        valid_inputs = self.getInputIMT(imt_out)
+        imt_in = imt_in.upper().strip()
+        imt_out = imt_out.upper().strip()
+        if imt_in not in valid_inputs and imt_in != imt_out:
+            raise ValueError('No conversion available from %r to %r' % (imt_in,
+                    imt_out))

--- a/shakelib/conversions/imt/bommer_alarcon_2006.py
+++ b/shakelib/conversions/imt/bommer_alarcon_2006.py
@@ -1,6 +1,7 @@
+# Local imports
+from shakelib.conversions.convert_imt import TypeConverter
 
-class BommerAlarcon2006(object):
-
+class BommerAlarcon2006(TypeConverter):
     """
     Class for conversion between PGV (units of cm/s) and PSA05 (units of g)
     by Bommer and Alarcon (2006).
@@ -8,50 +9,80 @@ class BommerAlarcon2006(object):
     - PSA05 stands for spectral acceleration with oscillator period of 0.5 sec
     - PGV is peak ground velocity.
 
-    To do
-        - Inherit from ConvertIMT class.
-
     References:
         Bommer, J. J., & Alarcon, J. E. (2006). The prediction and use of peak
         ground velocity. Journal of Earthquake Engineering, 10(01), 1-31.
         `[link] <http://www.worldscientific.com/doi/abs/10.1142/S1363246906002463>`__
-    """  # noqa
+    """
+    def __init__(self):
+        super().__init__()
+        # output_input dictionary where the key is the output
+        # and the value is a list of the possible inputs
+        self.output_input = {
+            'PGV': ['PSA05'],
+            'PSA05': ['PGV']
+        }
+        self.conversion_factor = 1.0 / (20.0) * 100.0 * 9.81
 
-    __vfact = 1.0 / (20.0) * 100.0 * 9.81
-
-    @staticmethod
-    def pgv2psa05(pgv):
+    def convertAmps(self, imt_in, imt_out, imt):
         """
-        Convert PGV in cm/s to PSA05 in g.
-        **Important:** PGV must be linear units.
+        Returns an array of converted IMT amplitude values.
 
         Args:
-            pgv: Numpy array or float of PGV values; linear units.
+            imt_in (str): OQ intensity measure type. Same as type as the input
+                values defined by the imt variable.
+            imt_out (str): OQ intensity measure type that the values will
+                be converted to.
+            imt (OpenQuake IMT): The intensity measure type of the input
+                ground motions. Valid IMTs are PGV, and SA.
 
         Returns:
-            Numpy array or float of PSA05 (spectral acceleration with
-            oscillator period of 0.5 sec) converted from PGV.
+            array: Numpy array of amps converted from imt_in to imt_out.
+
+        Raises:
+            ValueError: If not a valid conversion.
         """
-        return pgv / BommerAlarcon2006.__vfact
+        # Verify that this is a valid conversion
+        self._verifyConversion(imt_in, imt_out)
+        imt_in = imt_in.upper().strip()
+        imt_out = imt_out.upper().strip()
+        conversion_factor = self.conversion_factor
+        # Check which method to use
+        if imt_in == 'PSA05' and imt_out == 'PGV':
+            new_imt = self._convertToPGV(imt, conversion_factor)
+        elif imt_in == 'PGV' and imt_out == 'PSA05':
+            new_imt = self._convertToPSA05(imt, conversion_factor)
+        else:
+            raise ValueError('No conversion available from %r to %r' % (imt_in,
+                    imt_out))
+        return new_imt
 
     @staticmethod
-    def psa052pgv(psa05):
+    def _convertToPGV(psa05, conversion_factor):
         """
         Convert PSA05 (spectral acceleration with oscillator period of 0.5 sec)
         in g to PGV cm/s.
         **Important:** PSA10 must be linear units.
 
-        :param psa05:
-            Numpy array or float of PSA05 values; linear units.
-        :returns:
-            Numpy array or float of PGV converted from psa05.
+        Args:
+            psa05 (array): Numpy array or float of PSA05 values; linear units.
+
+        Returns
+            array: Numpy array or float of PGV converted from psa05.
         """
-        return psa05 * BommerAlarcon2006.__vfact
+        return psa05 * conversion_factor
 
     @staticmethod
-    def getVfact():
+    def _convertToPSA05(pgv, conversion_factor):
         """
-        :returns:
-            The Bommer and Alarcon (2006) conversion factor.
+        Convert PGV in cm/s to PSA05 in g.
+        **Important:** PGV must be linear units.
+
+        Args:
+            pgv (array): Numpy array or float of PGV values; linear units.
+
+        Returns:
+            array: Numpy array or float of PSA05 (spectral acceleration with
+            oscillator period of 0.5 sec) converted from PGV.
         """
-        return BommerAlarcon2006.__vfact
+        return pgv / conversion_factor

--- a/shakelib/multigmpe.py
+++ b/shakelib/multigmpe.py
@@ -133,8 +133,9 @@ class MultiGMPE(GMPE):
                     psa10, psa10sd = gmpe.get_mean_and_stddevs(
                         sites, rup, dists, SA(1.0), stddev_types)
                     psa10 = psa10 + lamps
-
-                lmean, lsd = NewmarkHall1982.psa102pgv(psa10, psa10sd[0])
+                nh82 = NewmarkHall1982()
+                lmean = nh82.convertAmps('PSA10', 'PGV', psa10)
+                lsd = nh82.convertSigmas('PSA10', 'PGV', psa10sd[0])
             else:
                 if self.HAS_SITE[i] is True:
                     lmean, lsd = gmpe.get_mean_and_stddevs(

--- a/tests/shakelib/conversions/imt/bommer_alarcon_2006_test.py
+++ b/tests/shakelib/conversions/imt/bommer_alarcon_2006_test.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python
 
+# Standard library imports
 import os.path
 import sys
 
-import shakelib.conversions.imt.bommer_alarcon_2006 as ba06
+# Third party imports
+import pytest
+
+# Local imports
+from shakelib.conversions.imt.bommer_alarcon_2006 import BommerAlarcon2006
+
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..', '..', '..'))
@@ -14,15 +20,37 @@ def test_bommeralarcon2006():
     # Inputs
     PGVin = 10
     PSA05in = 0.1
+    ba06 = BommerAlarcon2006()
 
-    # BommerAlarcon2006
-    PSA05out = ba06.BommerAlarcon2006.pgv2psa05(PGVin)
-    PGVout = ba06.BommerAlarcon2006.psa052pgv(PSA05in)
-    vfact = ba06.BommerAlarcon2006.getVfact()
+    # Test that the correct inputs are returned for valid outputs
+    input1 = ba06.getInputIMT('pgv  ')
+    input2 = ba06.getInputIMT('PGV')
+    input3 = ba06.getInputIMT('psa05  ')
+    input4 = ba06.getInputIMT('PSA05')
+    assert len(input1) == len(input2) == 1
+    assert input1[0] == input2[0] == 'PSA05'
+    assert len(input3) == len(input4) == 1
+    assert input3[0] == input4[0] == 'PGV'
 
+    # Test that invalid outputs return None
+    input5 = ba06.getInputIMT('INVALID')
+    assert input5 == None
+
+    # Test valid conversions
+    PSA05out = ba06.convertAmps('pgv', 'PSA05', PGVin)
+    PGVout = ba06.convertAmps('PSA05', 'PGV', PSA05in)
+    vfact = ba06.getConversionFactor()
     assert abs(PSA05out - 0.2038735983690112) < 0.0001
     assert abs(PGVout - 4.905000) < 0.001
     assert abs(vfact - 49.050000) < 0.001
+
+    # Test invalid conversions
+    with pytest.raises(Exception) as a:
+        tmp = ba06.convertAmps('INVALID', 'PSA05', PGVin)
+    with pytest.raises(Exception) as a:
+        tmp = ba06.convertAmps('PGV', 'INVALID', PGVin)
+    with pytest.raises(Exception) as a:
+        tmp = ba06.convertAmps('INVALID', 'INVALID', PGVin)
 
 
 if __name__ == '__main__':

--- a/tests/shakelib/conversions/imt/newmark_hall_1982_test.py
+++ b/tests/shakelib/conversions/imt/newmark_hall_1982_test.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
-
-import numpy as np
-
+# Standard library imports
 import os.path
 import sys
 
+# Third party imports
+import pytest
+import numpy as np
+
+# Local imports
 from shakelib.conversions.imt.newmark_hall_1982 import NewmarkHall1982
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
@@ -15,19 +18,37 @@ sys.path.insert(0, shakedir)
 
 def test_newmarkhall1982():
     # Inputs
-    # PGVin = np.log(10)
     PSA10in = np.log(0.1)
     sd = 0.6
+    nh82 = NewmarkHall1982()
 
-    # NewmarkHall1982
-    PGVout, PGVsdout = NewmarkHall1982.psa102pgv(PSA10in, sd)
-    mfact = NewmarkHall1982.getConversionFactor()
-    lnsig = NewmarkHall1982.getLnSigma()
+    # Test that the correct inputs are returned for valid outputs
+    input1 = nh82.getInputIMT('pgv  ')
+    input2 = nh82.getInputIMT('PGV')
+    assert len(input1) == len(input2) == 1
+    assert input1[0] == input2[0] == 'PSA10'
 
+    # Test that invalid outputs return None
+    input3 = nh82.getInputIMT('INVALID')
+    assert input3 == None
+
+    # Test valid conversions
+    PGVout = nh82.convertAmps('psa10', 'PGV', PSA10in)
+    PGVsdout = nh82.convertSigmas('psa10', 'PGV', sd)
+    mfact = nh82.getConversionFactor()
+    lnsig = nh82.getLnSigma()
     assert abs(PGVout - np.log(9.46658)) < 0.001
     assert abs(PGVsdout - 0.790489) < 0.001
     assert abs(mfact - 94.6658) < 0.001
     assert abs(lnsig - 0.5146578) < 0.001
+
+    # Test invalid conversions
+    with pytest.raises(Exception) as a:
+        tmp = nh82.convertAmps('INVALID', 'PSA05', PGVin)
+    with pytest.raises(Exception) as a:
+        tmp = nh82.convertAmps('PGV', 'INVALID', PGVin)
+    with pytest.raises(Exception) as a:
+        tmp = nh82.convertAmps('INVALID', 'INVALID', PGVin)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
IMT conversion classes were refactored to inherit from a base class (TypeConverter). The base class follows a similar structure to the ComponentConverter class used by IMC conversion child classes. The base class contains helper methods for verifying conversions, getting conversion factors, and getting input IMT types for a conversion.

**Conversions for BommerAlarcon2006:**
PGV can be converted to PSA05 and vice versa.

**Conversions for NewmarkHall1982:**
PSA10 can be converted to PGV. PSA10 standard deviation values can be converted to PGV standard deviations.