### PR TITLE
Add QuadRupture method for point/orientation

### DIFF
--- a/tests/shakelib/rupture_test.py
+++ b/tests/shakelib/rupture_test.py
@@ -725,6 +725,70 @@ depth="25.00" locstring="280km SE of Kodiak, Alaska" netid="us" network=""/>
         shutil.rmtree(tempdir)
 
 
+def test_fromOrientation():
+    py = [0, 0.5]
+    px = [0, 0.5]
+    pz = [10, 20]
+    dx = [5, 7]
+    dy = [8, 5]
+    width = [10, 40]
+    length = [20, 50]
+    strike = [0, 90]
+    dip = [30, 20]
+
+    # Rupture requires an origin even when not used:
+    origin = Origin({'id': 'test',
+                     'lon': 0, 'lat': 0,
+                     'depth': 5.0, 'mag': 7.0, 'netid': 'us',
+                     'network': '', 'locstring': '',
+                     'time': HistoricTime.utcfromtimestamp(time.time())})
+    rupture = QuadRupture.fromOrientation(px, py, pz, dx, dy, length, width,
+                        strike, dip, origin)
+    p1 = rupture._geojson['features'][0]['geometry']['coordinates'][0][0][0]
+    p2 = rupture._geojson['features'][0]['geometry']['coordinates'][0][0][1]
+    p3 = rupture._geojson['features'][0]['geometry']['coordinates'][0][0][2]
+    p4 = rupture._geojson['features'][0]['geometry']['coordinates'][0][0][3]
+    p5 = rupture._geojson['features'][0]['geometry']['coordinates'][0][1][0]
+    p6 = rupture._geojson['features'][0]['geometry']['coordinates'][0][1][1]
+    p7 = rupture._geojson['features'][0]['geometry']['coordinates'][0][1][2]
+    p8 = rupture._geojson['features'][0]['geometry']['coordinates'][0][1][3]
+
+    # Check depths
+    np.testing.assert_allclose(p1[2], 6)
+    np.testing.assert_allclose(p2[2], 6)
+    np.testing.assert_allclose(p3[2], 11)
+    np.testing.assert_allclose(p4[2], 11)
+    np.testing.assert_allclose(p5[2], 18.2898992834)
+    np.testing.assert_allclose(p6[2], 18.2898992834)
+    np.testing.assert_allclose(p7[2], 31.9707050164)
+    np.testing.assert_allclose(p8[2], 31.9707050164)
+
+    # Exception raised if no origin
+    with pytest.raises(Exception) as a:
+        rupture = QuadRupture.fromOrientation(px, py, pz, dx, dy, length, width,
+                            strike, dip, None)
+
+    # Exception raised if different lengths of arrays
+    with pytest.raises(Exception) as a:
+        py = [0, 2]
+        px = [0]
+        pz = [10]
+        dx = [5]
+        dy = [8]
+        width = [10]
+        length = [20]
+        strike = [0]
+        dip = [30]
+
+        origin = Origin({'id': 'test',
+                         'lon': 0, 'lat': 0,
+                         'depth': 5.0, 'mag': 7.0, 'netid': 'us',
+                         'network': '', 'locstring': '',
+                         'time': HistoricTime.utcfromtimestamp(time.time())})
+        rupture = QuadRupture.fromOrientation(px, py, pz, dx, dy, length, width,
+                            strike, dip, origin)
+
+
 if __name__ == "__main__":
     test_text_to_json()
     test_rupture_from_dict()
@@ -737,3 +801,4 @@ if __name__ == "__main__":
     test_incorrect()
     test_fromTrace()
     test_with_quakeml()
+    test_fromOrientation()


### PR DESCRIPTION
Implements [point_at](https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/geo/geodetic.py#L396) and [fromTrace](https://github.com/usgs/shakemap/blob/master/shakelib/rupture/quad_rupture.py#L193) in order to return a QuadRupture instance from a known point, shape, and orientation of a plane as illustrated:
![screen shot 2018-05-23 at 12 04 45 pm](https://user-images.githubusercontent.com/26904055/40443848-c9ace324-5e84-11e8-9233-9bfbe2f4c6d6.png)
P1 and P2 are acquired using a bearing-distance equation (`point_at`) in **lat/lon space,** then P1, P2, the dip angle, and the width are used with `from_trace` to get the rest of the quadrilateral.

The bearing/distance from Point to P1 were derived as follows:
![screen shot 2018-05-23 at 12 21 44 pm](https://user-images.githubusercontent.com/26904055/40443970-2f276d32-5e85-11e8-9373-1fd5ae68af49.png)

The bearing/distance from P1 to P2 are the length and strike angle respectively.

The depth of P1 was calculated using the following geometry and the equation **P1_depth = Point_depth - dy*sin(dip angle)**:
![screen shot 2018-05-23 at 12 21 32 pm](https://user-images.githubusercontent.com/26904055/40444020-62503388-5e85-11e8-9d7c-22cd79b6ae41.png)
