### PR TITLE
Test

### DIFF
--- a/tests/shakemap/programs/profile_test.py
+++ b/tests/shakemap/programs/profile_test.py
@@ -119,7 +119,7 @@ def test_profile():
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               shell=False)
-        ipath = os.path.join(os.path.abspath(os.sep), 'zzx?*@yzzskx') + '\n'
+        ipath = os.path.join(os.path.abspath(os.sep), 'zzx/yzzskx') + '\n'
         op.communicate((ipath + ipath + ipath).encode('ascii'))
         assert op.returncode
 
@@ -129,7 +129,7 @@ def test_profile():
                               stderr=subprocess.PIPE,
                               shell=False)
         ipath = os.path.join(shakedir, 'junkprofile', 'install') + '\n'
-        dpath = os.path.join(os.path.abspath(os.sep), 'zzxyzzskx') + '\n'
+        dpath = os.path.join(os.path.abspath(os.sep), 'zzxy/zzskx') + '\n'
         op.communicate((ipath + dpath + dpath + dpath).encode('ascii'))
         assert op.returncode
 

--- a/tests/shakemap/programs/profile_test.py
+++ b/tests/shakemap/programs/profile_test.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
 import os
-import shutil
 import subprocess
 import tempfile
 
-from shakemap.utils.config import get_config_paths
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..', '..'))
@@ -121,7 +119,7 @@ def test_profile():
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               shell=False)
-        ipath = os.path.join(os.path.abspath(os.sep), 'zzxyzzskx') + '\n'
+        ipath = os.path.join(os.path.abspath(os.sep), 'zzx?*@yzzskx') + '\n'
         op.communicate((ipath + ipath + ipath).encode('ascii'))
         assert op.returncode
 


### PR DESCRIPTION
One of the profile tests was failing because the profile setup was supposed to fail by providing paths that should fail. This test was fine on Travis (Ubuntu) and CircleCI (OSX) but started failing in Jenkins (CentOS) because the old paths were being accepted when they should fail. So I'm adding some illegal characters that should make the test pass by failing to create the requested directories. 