### PR TITLE
Check tests for shakelib/conversions

### DIFF
--- a/shakelib/conversions/convert_imc.py
+++ b/shakelib/conversions/convert_imc.py
@@ -44,7 +44,7 @@ class ComponentConverter(ABC):
         return amps
 
     @abstractmethod
-    def convertAmpsOnce(self, imt, amps, rrups, mag):
+    def convertAmpsOnce(self, imt, amps, rrups=None, mag=None):
         """
         Return an array of amps converted from one IMC to another.
 

--- a/shakelib/conversions/imc/beyer_bommer_2006.py
+++ b/shakelib/conversions/imc/beyer_bommer_2006.py
@@ -160,7 +160,7 @@ class BeyerBommer2006(ComponentConverter):
             const.IMC.GREATER_OF_TWO_HORIZONTAL:
                 dict(list(zip(self.__sa_col_names, [1.1, 1.2, 0.04, 0.07, 1.02])))}
 
-    def convertAmpsOnce(self, imt, amps, rrups, mag):
+    def convertAmpsOnce(self, imt, amps, rrups=None, mag=None):
         """
         Returns amps converted from one IMC to another.
 
@@ -170,18 +170,19 @@ class BeyerBommer2006(ComponentConverter):
             - IMC type 'VERTICAL' is not supported
 
         Args:
-            amps (array): Numpy array of ground motion amplitudes.
-            imc_in (IMC): OpenQuake IMC type of the input amp array.
-                `[link] <http://docs.openquake.org/oq-hazardlib/master/const.html?highlight=imc#openquake.hazardlib.const.IMC>`__
-            imc_out (IMC): Desired OpenQuake IMC type of the output amps.
-                `[link] <http://docs.openquake.org/oq-hazardlib/master/const.html?highlight=imc#openquake.hazardlib.const.IMC>`__
             imt (IMT): OpenQuake IMT of the input amps (must be one of PGA,
                 PGV, or SA).
                 `[link] <http://docs.openquake.org/oq-hazardlib/master/imt.html>`
 
+            amps (array): Numpy array of ground motion amplitudes.
+            rrups (array): A numpy array of the same shape as amps,
+                containing the rupture distances of the ground motions.
+                Ignored by this method.
+            mag (float): The earthquake magnitude. Default is None.
+                 Ignored by this method.
+
         Returns:
             array: Numpy array of amps converted from imc_in to imc_out.
-
         """
 
         denom = self.__GM2other(imt, self.imc_in)
@@ -199,13 +200,9 @@ class BeyerBommer2006(ComponentConverter):
             - IMC types 'VERTICAL' and 'HORIZONTAL' are not supported
 
         Args:
-            sigmas (array): Numpy array of standard deviations.
-            imc_in (IMC): OpenQuake IMC type of the input sigmas array.
-                `[link] <http://docs.openquake.org/oq-hazardlib/master/const.html?highlight=imc#openquake.hazardlib.const.IMC>`__
-            imc_out (IMC): Desired OpenQuake IMC type of the output sigmas.
-                `[link] <http://docs.openquake.org/oq-hazardlib/master/const.html?highlight=imc#openquake.hazardlib.const.IMC>`__
             imt (IMT): OpenQuake IMT of the input sigmas (must be one of PGA,
                  PGV, or SA) `[link] <http://docs.openquake.org/oq-hazardlib/master/imt.html>`__
+            sigmas (array): Numpy array of standard deviations.
 
         Returns:
             array: Numpy array of standard deviations converted from imc_in to

--- a/shakelib/conversions/imc/boore_kishida_2017.py
+++ b/shakelib/conversions/imc/boore_kishida_2017.py
@@ -102,7 +102,7 @@ class BooreKishida2017(ComponentConverter):
         self.path = self.getShortestPath(self.conversion_graph,
                 self.imc_in, self.imc_out)
 
-    def convertAmpsOnce(self, imt, amps, rrups, mag):
+    def convertAmpsOnce(self, imt, amps, rrups=None, mag=None):
         """
         Return an array of amps converted from one IMC to another.
 
@@ -152,7 +152,6 @@ class BooreKishida2017(ComponentConverter):
             amps = amps - ln_ratio
         else:
             amps = amps + ln_ratio
-
         return amps
 
     def convertSigmasOnce(self, imt, sigmas):
@@ -319,5 +318,3 @@ class BooreKishida2017(ComponentConverter):
             self.pars = None
         else:
             self.pars = pd.read_csv(filename)
-
-BooreKishida2017('blerg', 'blerg')

--- a/tests/shakelib/conversions/imt/bommer_alarcon_2006_test.py
+++ b/tests/shakelib/conversions/imt/bommer_alarcon_2006_test.py
@@ -44,14 +44,13 @@ def test_bommeralarcon2006():
     assert abs(PGVout - 4.905000) < 0.001
     assert abs(vfact - 49.050000) < 0.001
 
-    # Test invalid conversions
+    # Test invalid conversions types
     with pytest.raises(Exception) as a:
         tmp = ba06.convertAmps('INVALID', 'PSA05', PGVin)
     with pytest.raises(Exception) as a:
         tmp = ba06.convertAmps('PGV', 'INVALID', PGVin)
     with pytest.raises(Exception) as a:
         tmp = ba06.convertAmps('INVALID', 'INVALID', PGVin)
-
 
 if __name__ == '__main__':
     test_bommeralarcon2006()

--- a/tests/shakelib/conversions/imt/newmark_hall_1982_test.py
+++ b/tests/shakelib/conversions/imt/newmark_hall_1982_test.py
@@ -5,11 +5,12 @@ import os.path
 import sys
 
 # Third party imports
-import pytest
 import numpy as np
+import pytest
 
 # Local imports
 from shakelib.conversions.imt.newmark_hall_1982 import NewmarkHall1982
+
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..', '..', '..'))


### PR DESCRIPTION
Increased coverage when possible and validated that output values were tested, as per #603.

Checked and updated documentation, and edited `convertAmpsOnce` with defaults for rrups and mag to account for use with BeyerBommer2006.