### PR TITLE
Check shakelib/utils tests

### DIFF
--- a/tests/shakelib/utils/container_test.py
+++ b/tests/shakelib/utils/container_test.py
@@ -1,22 +1,25 @@
 #!/usr/bin/env python
 
 # stdlib imports
-import os.path
-import sys
+import datetime
 import io
 import numpy as np
-import datetime
-import tempfile
-import pytest
 import random
 import string
+import sys
+import tempfile
+import os.path
 
+# third party imports
+from mapio.geodict import GeoDict
+from mapio.grid2d import Grid2D
+import pytest
+
+# local imports
 from shakelib.utils.containers import ShakeMapInputContainer
 from shakelib.utils.containers import ShakeMapOutputContainer
 from shakelib.rupture.point_rupture import PointRupture
 
-from mapio.geodict import GeoDict
-from mapio.grid2d import Grid2D
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..', '..'))
@@ -199,8 +202,14 @@ def test_output_container():
 
     f, datafile = tempfile.mkstemp()
     os.close(f)
+
     try:
         container = ShakeMapOutputContainer.create(datafile)
+        # LookupError raised if trying to dropIMTs if there are none
+        with pytest.raises(LookupError):
+            container.dropIMT('mmi')
+
+        # Add imts
         container.setIMTGrids('mmi',
                               mean_mmi_maximum_grid, mean_mmi_maximum_metadata,
                               std_mmi_maximum_grid, std_mmi_maximum_metadata,

--- a/tests/shakelib/utils/geodetic_distance_test.py
+++ b/tests/shakelib/utils/geodetic_distance_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
+# third party imports
 import numpy as np
 
+# local imports
 from shakelib.utils.distance import (geodetic_distance_fast,
                                      geodetic_distance_haversine)
 

--- a/tests/shakelib/utils/str_imt_test.py
+++ b/tests/shakelib/utils/str_imt_test.py
@@ -32,6 +32,12 @@ def test_imt():
     except ValueError as ve:
         assert 1 == 1
 
+    # Test that a fileimt that is the same as ['PGA', 'PGV', 'MMI']
+    # is simply returned
+    assert file_to_oq('PGA') == 'PGA'
+    assert file_to_oq('PGV') == 'PGV'
+    assert file_to_oq('MMI') == 'MMI'
+
 
 if __name__ == '__main__':
     test_imt()

--- a/tests/shakelib/utils/utils_test.py
+++ b/tests/shakelib/utils/utils_test.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
+
+# stdlib imports
 import io
 import os.path
+
+# third party imports
+import numpy as np
 import pytest
 
-from shakelib.rupture.origin import Origin
-from shakelib.rupture.factory import get_rupture
+# local imports
+from shakelib.utils.exception import ShakeLibException
 from shakelib.utils.utils import get_extent, is_stable
+from shakelib.rupture.factory import get_rupture
+from shakelib.rupture.origin import Origin
 
-import numpy as np
 
 homedir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(homedir, 'utils_data')
@@ -157,6 +163,11 @@ def test_extent_config():
     cmp_extent = [-100, -95, 32, 37]
     np.testing.assert_almost_equal(extent, cmp_extent)
 
+def test_exception():
+    exception = ShakeLibException('Test exception')
+    # Check __str__ override is correct
+    assert str(exception) == "'Test exception'"
+
 
 if __name__ == '__main__':
     test_get_extent_small_point()
@@ -167,3 +178,4 @@ if __name__ == '__main__':
     test_get_extent_stable_large()
     test_is_stable()
     test_extent_config()
+    test_exception()


### PR DESCRIPTION
Increased coverage when possible and checked to make sure that output values were tested, as per #607.
These were already tested very well. Minor checks added for bad parameters and the exception class.

## Summary of tests against target values:

**containers.py**
- tested against target event text
- mean_metadata, std_metadata, standard deviation, mean tested against target
- drop and get imt methods checked against lists
- output arrays checked against targets

**distance.py**
- using geodetic_distance_fast tested against targets
- using geodetic_distance_haversine tested against targets

**imt_string.py**
- outputs from file_to_oq and oq_to_file tested against correct strings

**utils.py**
-  extent output tested against correct values for
   - Wenchuan event
   - small Wenchuan event
   - incorrect parameters
   - Oklahoma event
   - large Oklahoma event
- is_stable checked for differing locations
   - Gulf of Guinea
   - Nashville
   - Wasatch
   - South Australia
   - South Pacific
   - Brazil, near border of Bolivia
- extent from config tested against target values

## Full Summary: 
[Test Checks - Shakelib Utils.pdf](https://github.com/usgs/shakemap/files/2040809/Test.Checks.-.Shakelib.Utils.pdf)


