### PR TITLE
Check tests for shakelib's top level modules

### DIFF
--- a/tests/shakelib/distance_test.py
+++ b/tests/shakelib/distance_test.py
@@ -4,26 +4,28 @@
 import os.path
 import sys
 
-# third party
-import numpy as np
-import pandas as pd
-import pytest
-import time
-
+# third party imports
 from openquake.hazardlib.geo.utils import get_orthographic_projection
 from openquake.hazardlib.gsim.abrahamson_2014 import AbrahamsonEtAl2014
 from openquake.hazardlib.gsim.berge_thierry_2003 \
     import BergeThierryEtAl2003SIGMA
 import openquake.hazardlib.geo as geo
+import numpy as np
+import pandas as pd
+import pytest
+import time
 
-from shakelib.rupture.quad_rupture import QuadRupture
-from shakelib.rupture.point_rupture import PointRupture
-from shakelib.rupture.origin import Origin
-from shakelib.rupture.gc2 import _computeGC2
-from shakelib.sites import Sites
+# local imports
 from shakelib.distance import Distance
 from shakelib.distance import get_distance
+from shakelib.rupture.edge_rupture import EdgeRupture
+from shakelib.rupture.gc2 import _computeGC2
+from shakelib.rupture.origin import Origin
+from shakelib.rupture.point_rupture import PointRupture
+from shakelib.rupture.quad_rupture import QuadRupture
+from shakelib.sites import Sites
 from impactutils.time.ancient_time import HistoricTime
+
 
 do_tests = True
 
@@ -63,6 +65,7 @@ def test_san_fernando():
                      'depth': 5.0, 'mag': 7.0, 'netid': '',
                      'network': '', 'locstring': '',
                      'time': HistoricTime.utcfromtimestamp(int(time.time()))})
+
     rup = QuadRupture.fromVertices(
         lon0, lat0, z0, lon1, lat1, z1, lon2, lat2, z2, lon3, lat3, z3,
         origin)
@@ -208,6 +211,9 @@ def test_exceptions():
     with pytest.raises(Exception) as e:  # noqa
         get_distance(dist_types, sctx.lats, sctx.lons[0:4, ],
                      np.zeros_like(sctx.lons), rup)
+    # Exception when not a GMPE subclass
+    with pytest.raises(Exception) as e:  # noqa
+        Distance([None], [-118.2], [34.1], [1], rupture=None)
 
 
 def test_distance_no_rupture():

--- a/tests/shakelib/sites_test.py
+++ b/tests/shakelib/sites_test.py
@@ -4,12 +4,14 @@
 import sys
 import os.path
 
+# third party imports
 import numpy as np
 import pytest
 
 # local imports
 from shakelib.sites import Sites
 import shakelib.sites as sites
+
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..'))
@@ -328,6 +330,24 @@ def test_sites(vs30file=None):
          [686.,  686.,  686.,  686.,  686.,  686.,  686.,  686.,  686.,
           686.,  686.]])
     np.testing.assert_allclose(grd, grd_target)
+
+    # Test bounds
+    nx, ny = mysite.getNxNy()
+    assert nx == len(grd_target[0])
+    assert ny == len(grd_target)
+
+    # Check exception for invalid lat/lon shapes
+    with pytest.raises(Exception) as a:
+        sample_dict = {'lats': np.array(['0','0']),
+                'lons': np.array(['0'])}
+        sc = mysite.getSitesContext(lldict=sample_dict, rock_vs30=None)
+
+    # Check invalid file
+    with pytest.raises(Exception) as a:
+        vs30file = os.path.join(homedir, 'sites_data/Wrong.grd')
+        mysite = Sites.fromCenter(cx, cy, xspan, yspan, dx, dy,
+                                  vs30File=vs30file, padding=True,
+                                  resample=False)
 
 
 if __name__ == '__main__':

--- a/tests/shakelib/station_test.py
+++ b/tests/shakelib/station_test.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 
 # stdlib modules
-import sys
 import os.path
 import pickle
+import sys
 
 # third party modules
 import numpy as np
 
 # local imports
 from shakelib.station import StationList
+
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..'))
@@ -76,9 +77,13 @@ def test_station():
 
     inputfile = os.path.join(datadir, 'hist_dat.xml')
     dyfifile = os.path.join(datadir, 'dyfi_dat.xml')
+    len_stat1 = len(stations.getStationDictionary(instrumented=True)[0]['id'])
     xmlfiles = [inputfile, dyfifile]
-
     stations = stations.addData(xmlfiles)
+    len_stat2 = len(stations.getStationDictionary(instrumented=True)[0]['id'])
+
+    # Check that more stations were added
+    assert len_stat2 > len_stat1
 
     df1, _ = stations.getStationDictionary(instrumented=True)
     df2, _ = stations.getStationDictionary(instrumented=False)
@@ -118,8 +123,21 @@ def test_station2():
     stations = StationList.loadFromXML(xmlfiles, ":memory:")
 
     df1, _ = stations.getStationDictionary(instrumented=True)
+    # Check Keys pressent
+    assert 'PGA' in _
+    assert 'PGV' in _
+    assert 'SA(0.3)' in _
+    assert 'SA(1.0)' in _
+    assert 'SA(3.0)' in _
+    assert 'PGV_sd' in df1
+    assert 'PGV' in df1
+    assert 'SA(0.3)' in df1
+    assert 'SA(1.0)' in df1
+    assert 'SA(3.0)' in df1
+    assert 'id' in df1
     df2, _ = stations.getStationDictionary(instrumented=False)
-
+    # Check Keys pressent
+    assert 'MMI' in _
     ppath = os.path.abspath(os.path.join(datadir, '..', 'database',
                                          'test3.pickle'))
     if SAVE:

--- a/tests/shakelib/virtualipe_test.py
+++ b/tests/shakelib/virtualipe_test.py
@@ -6,21 +6,22 @@ import os.path
 
 # third party modules
 import numpy as np
-from openquake.hazardlib.gsim.chiou_youngs_2014 import ChiouYoungs2014
 from openquake.hazardlib.gsim.boore_2014 import BooreEtAl2014
+from openquake.hazardlib.gsim.chiou_youngs_2014 import ChiouYoungs2014
 import openquake.hazardlib.const as oqconst
 from openquake.hazardlib.imt import MMI, PGA, PGV, SA
 import pytest
 
 # local imports
-from shakelib.virtualipe import VirtualIPE
+from shakelib.distance import Distance
 from shakelib.gmice.wgrw12 import WGRW12
 from shakelib.multigmpe import MultiGMPE
-from shakelib.distance import Distance
-from shakelib.sites import Sites
 from shakelib.rupture.origin import Origin
 from shakelib.rupture.factory import get_rupture
+from shakelib.sites import Sites
 from shakelib.utils.exception import ShakeLibException
+from shakelib.virtualipe import VirtualIPE
+
 
 homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..'))
@@ -210,6 +211,13 @@ def test_virtualipe():
     tot = np.sqrt(
         mmi_sd_variable_vs30_intra[1]**2 + mmi_sd_variable_vs30_intra[2]**2)
     assert(np.allclose(tot, mmi_sd_variable_vs30_intra[0], rtol=1e-2))
+
+    # Run through mgm = mgm + fd if fd is available
+    # In this case fd = 0, so the ouput is still the same values
+    mmi_fd, mmi_fdsd = ipe.get_mean_and_stddevs(sx, rx, dx, MMI(),
+            sd_types, fd=0)
+    assert(np.allclose(mmi_fd, mmi_rjb))
+    assert(np.allclose(mmi_fdsd, mmi_sd_rjb))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Increased coverage when possible and validated that the output values were tested, as per #611. Overall, these were well tested to begin with. Only very minor additions were made.

## Short summary of tests against target values:

**distance.py**
- output GC2 coordinates (U and T) with target San Fernando data
- tested exceptions with a Vs30 grid file
- output rjb  and rrup values against targets for different tectonic regions (volcanic, active shallow crust, stable shallow crust) with multiple mechanisms
- output rhypo, rx, rjb, ry0, and rrup values against targets

**multigmpe.py**
- output mean and standard deviation values tested against set targets (for different sets of gmpes)
- filter_gmpe tested against gmpe list
- tested with multiple config files
- output site amplifications values tested with target data

**sites.py**
- output depth parameters tested against targets
- output grid from vs30 file tested against targets
- output boolean array indicating whether site is in the subduction zone tested

**station.py** 
- tested loading Calexico, Northridge, Wenchuan xml files and compared dataframes
- checked for required keys in dataframe

**virtualipe_test.py**
- mmi and standard deviation outputs checked with Calexico data

## Full summary:
[Test Checks - Top Level Shakelib.pdf](https://github.com/usgs/shakemap/files/2040808/Test.Checks.-.Top.Level.Shakelib.pdf)
