### PR TITLE
Install cleanup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,11 +50,11 @@ dependencies:
 - versioneer
 - paramiko
 - pip:
-  - et-xmlfile==1.0.1
-  - ipython-genutils==0.2.0
-  - jupyter-client==5.1.0
-  - jupyter-console==5.2.0
-  - jupyter-core==4.4.0
-  - prompt-toolkit==1.0.15
-  - sphinx-argparse==0.2.1
+  - et-xmlfile
+  - ipython-genutils
+  - jupyter-client
+  - jupyter-console
+  - jupyter-core
+  - prompt-toolkit
+  - sphinx-argparse
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if [ "$unamestr" == 'Linux' ]; then
     env_file=environment_linux.yml
 elif [ "$unamestr" == 'FreeBSD' ] || [ "$unamestr" == 'Darwin' ]; then
     prof=~/.bash_profile
-    mini_conda_url=https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
+    mini_conda_url=https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     matplotlibdir=~/.matplotlib
     env_file=environment_osx.yml
 else


### PR DESCRIPTION
Removed version numbers from pip installs in environment.xml and changed typo in OSX miniconda install to use miniconda3 rather than miniconda2. I noticed these things while trying to fix the geospatial package incompatibilities, but these changes will not fix the problem and I expect that this PR will fail on all of our CI systems. 