### PR TITLE
Point source variance

### DIFF
--- a/shakelib/distance.py
+++ b/shakelib/distance.py
@@ -128,6 +128,8 @@ class Distance(object):
             ddict = get_distance(list(requires), lat, lon, dep, self._rupture)
         for method in requires:
             (context.__dict__)[method] = ddict[method]
+            if method in ('rrup', 'rjb'):
+                (context.__dict__)[method + '_var'] = ddict[method + '_var']
 
         return context
 
@@ -225,10 +227,12 @@ def get_distance(methods, lat, lon, dep, rupture, dx=0.5):
     # -------------------------------------------------------------------------
     gc2_distances = set(['rx', 'ry', 'ry0', 'U', 'T'])
     if 'rrup' in methods:
-        distdict['rrup'] = rupture.computeRrup(lon, lat, dep)
+        distdict['rrup'], distdict['rrup_var'] = rupture.computeRrup(lon, lat,
+                                                                     dep)
 
     if 'rjb' in methods:
-        distdict['rjb'] = rupture.computeRjb(lon, lat, dep)
+        distdict['rjb'], distdict['rjb_var'] = rupture.computeRjb(lon, lat,
+                                                                  dep)
 
     # If any of the GC2-related distances are requested, may as well do all
     if len(set(methods).intersection(gc2_distances)) > 0:

--- a/shakelib/rupture/base.py
+++ b/shakelib/rupture/base.py
@@ -216,7 +216,7 @@ class Rupture(ABC):
         return repi
 
     @abstractmethod
-    def computeRjb(self, lon, lat, depth, var=False):  # pragma: no cover
+    def computeRjb(self, lon, lat, depth):  # pragma: no cover
         """
         Method for computing Joyner-Boore distance.
 
@@ -224,8 +224,6 @@ class Rupture(ABC):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction. Only meaningful
-                for the PointRupture subclass.
 
         Returns:
            array: Joyner-Boore distance (km).
@@ -234,7 +232,7 @@ class Rupture(ABC):
         pass
 
     @abstractmethod
-    def computeRrup(self, lon, lat, depth, var=False):  # pragma: no cover
+    def computeRrup(self, lon, lat, depth):  # pragma: no cover
         """
         Method for computing rupture distance.
 
@@ -242,8 +240,6 @@ class Rupture(ABC):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction. Only meaningful
-                for the PointRupture subclass.
 
         Returns:
            array: Rupture distance (km).

--- a/shakelib/rupture/edge_rupture.py
+++ b/shakelib/rupture/edge_rupture.py
@@ -519,7 +519,7 @@ class EdgeRupture(Rupture):
 
         return qlist
 
-    def computeRrup(self, lon, lat, depth, var=False):
+    def computeRrup(self, lon, lat, depth):
         """
         Method for computing rupture distance.
 
@@ -527,16 +527,11 @@ class EdgeRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction. Unused, and
-                will raise an exception if not False.
 
         Returns:
-           array: Rupture distance (km).
+           tuple: A tuple of an array of rupture distance (km), and None.
 
         """
-
-        if var is True:
-            raise ValueError('var must be False for EdgeRupture')
 
         mesh_dx = self._mesh_dx
 
@@ -599,9 +594,9 @@ class EdgeRupture(Rupture):
 
         dist = np.reshape(dist, oldshape)
 
-        return dist
+        return dist, None
 
-    def computeRjb(self, lon, lat, depth, var=False):
+    def computeRjb(self, lon, lat, depth):
         """
         Method for computing Joyner-Boore distance.
 
@@ -609,16 +604,11 @@ class EdgeRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction. Unused, and
-                will raise an exception if not False.
 
         Returns:
-           array: Joyner-Boore distance (km).
+           tuple: A tuple of an array of Joyner-Boore distance (km), and None.
 
         """
-
-        if var is True:
-            raise ValueError('var must be False for EdgeRupture')
 
         mesh_dx = self._mesh_dx
 
@@ -681,7 +671,7 @@ class EdgeRupture(Rupture):
 
         dist = np.reshape(dist, oldshape)
 
-        return dist
+        return dist, None
 
     def computeGC2(self, lon, lat, depth):
         """

--- a/shakelib/rupture/point_rupture.py
+++ b/shakelib/rupture/point_rupture.py
@@ -128,7 +128,7 @@ class PointRupture(Rupture):
         PointRupture."""
         return self._origin.depth
 
-    def computeRjb(self, lon, lat, depth, var=False):
+    def computeRjb(self, lon, lat, depth):
         """
         Convert point-distances to Joyner-Boore distances based on magnitude.
 
@@ -136,17 +136,14 @@ class PointRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction.
 
         Returns:
-            If var is True then this returns a tuple of two arrays: first, the
-                predicted Rjb values, and second an array of the variance of
-                those predictions. If var is False then just the first element
-                of the tuple is returned.
+            tuple: A tuple of two arrays: first, the predicted Rjb values,
+            and second an array of the variance of those predictions.
         """
-        return self._computeRdist('Rjb', lon, lat, depth, var)
+        return self._computeRdist('Rjb', lon, lat, depth)
 
-    def computeRrup(self, lon, lat, depth, var=False):
+    def computeRrup(self, lon, lat, depth):
         """
         Convert point-distances to rupture distances based on magnitude.
 
@@ -154,17 +151,14 @@ class PointRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction.
 
         Returns:
-            If var is True then this returns a tuple of two arrays: first, the
-                predicted Rrup, and second an array of the variance of
-                those predictions. If var is False then just the first element
-                of the tuple is returned.
+            tuple: A tuple of two arrays: first, the predicted Rrup, and
+            second an array of the variance of those predictions.
         """
-        return self._computeRdist('Rrup', lon, lat, depth, var)
+        return self._computeRdist('Rrup', lon, lat, depth)
 
-    def _computeRdist(self, rtype, lon, lat, depth, var):
+    def _computeRdist(self, rtype, lon, lat, depth):
         """
         Helper function to actually do the approximate fault distance
         computations.
@@ -174,14 +168,12 @@ class PointRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction.
 
         Returns:
-            If var is True then this returns a tuple of two arrays: first, the
-                predicted approximate fault distance values (either Rjb or
-                Rrup, depending on the 'type' argument), and second an array of
-                the variance of those predictions. If var is False then just
-                the first element of the tuple is returned.
+            tuple: A tuple of two arrays: first, the predicted approximate
+            fault distance values (either Rjb or Rrup, depending on the
+            'type' argument), and second an array of the variance of those
+            predictions.
         """
         if rtype == 'Rjb':
             dtype = DistType.Rjb
@@ -250,12 +242,9 @@ class PointRupture(Rupture):
         mags = np.full_like(repis, origin.mag)
 
         r_hat = p2f.r2r(repis, mags)
+        r_var = p2f.var(repis, mags)
 
-        if var is True:
-            r_var = p2f.var(repis, mags)
-            return (r_hat, r_var)
-        else:
-            return r_hat
+        return (r_hat, r_var)
 
     def computeGC2(self, lon, lat, depth):
         """

--- a/shakelib/rupture/quad_rupture.py
+++ b/shakelib/rupture/quad_rupture.py
@@ -78,7 +78,8 @@ class QuadRupture(Rupture):
         SMALL_DISTANCE = 2e-03  # 2 meters
         depth = np.nan
 
-        tmp = self.computeRjb(np.array([lon]), np.array([lat]), np.array([0]))
+        tmp, _ = self.computeRjb(np.array([lon]), np.array([lat]),
+                                 np.array([0]))
         if tmp > SMALL_DISTANCE:
             return depth
 
@@ -1018,7 +1019,7 @@ class QuadRupture(Rupture):
         rupture = Mesh(self._lon, self._lat, self._depth)
         return rupture
 
-    def computeRjb(self, lon, lat, depth, var=False):
+    def computeRjb(self, lon, lat, depth):
         """
         Method for computing Joyner-Boore distance.
 
@@ -1026,16 +1027,11 @@ class QuadRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction. Unused, and
-                will raise an exception if not False.
 
         Returns:
-           array: Joyner-Boore distance (km).
+           tuple: A tuple of an array of Joyner-Boore distance (km), and None.
 
         """
-
-        if var is True:
-            raise ValueError('var must be False for EdgeRupture')
 
         # ---------------------------------------------------------------------
         # Sort out sites
@@ -1071,9 +1067,9 @@ class QuadRupture(Rupture):
             minrjb = np.minimum(minrjb, rjbdist)
 
         minrjb = minrjb.reshape(oldshape)
-        return minrjb
+        return minrjb, None
 
-    def computeRrup(self, lon, lat, depth, var=False):
+    def computeRrup(self, lon, lat, depth):
         """
         Method for computing rupture distance.
 
@@ -1081,16 +1077,11 @@ class QuadRupture(Rupture):
             lon (array): Numpy array of longitudes.
             lat (array): Numpy array of latitudes.
             depth (array): Numpy array of depths (km; positive down).
-            var (bool): Also return variance of prediction. Unused, and
-                will raise an exception if not False.
 
         Returns:
-           array: Rupture distance (km).
+           tuple: A tuple of an array of Rupture distance (km), and None.
 
         """
-
-        if var is True:
-            raise ValueError('var must be False for EdgeRupture')
 
         # ---------------------------------------------------------------------
         # Sort out sites
@@ -1116,7 +1107,7 @@ class QuadRupture(Rupture):
             minrrup = np.minimum(minrrup, rrupdist)
 
         minrrup = minrrup.reshape(oldshape)
-        return minrrup
+        return minrrup, None
 
     def computeGC2(self, lon, lat, depth):
         """

--- a/shakelib/virtualipe.py
+++ b/shakelib/virtualipe.py
@@ -147,13 +147,14 @@ class VirtualIPE(GMPE):
         # Total and intra-event uncertanty are inflated by the uncertainty
         # of the conversion; inter-event uncertainty is not.
         #
+        ntypes = len(stddev_types)
         nsd = len(sdev)
         mmi_sd = [None] * nsd
         gm2mi_var = (self.gmice.getGM2MIsd()[self.imt])**2
         dmda *= dmda
         for i in range(nsd):
             gm_var_in_mmi = dmda * sdev[i]**2
-            if stddev_types[i] == const.StdDev.INTER_EVENT:
+            if stddev_types[i % ntypes] == const.StdDev.INTER_EVENT:
                 mmi_sd[i] = np.sqrt(gm_var_in_mmi)
             else:
                 mmi_sd[i] = np.sqrt(gm2mi_var + gm_var_in_mmi)

--- a/tests/shakelib/rupture/rupture_distance_tests.py
+++ b/tests/shakelib/rupture/rupture_distance_tests.py
@@ -3,7 +3,6 @@ import os
 import sys
 import numpy as np
 import time
-import pytest
 
 from openquake.hazardlib.geo.utils import OrthographicProjection
 
@@ -343,12 +342,8 @@ def test_EdgeRupture_vs_QuadRupture():
                      'network': '', 'locstring': '',
                      'time': HistoricTime.utcfromtimestamp(time.time())})
     qrup = QuadRupture.fromTrace(xp0, yp0, xp1, yp1, zp, widths, dips, origin)
-    with pytest.raises(ValueError):
-        rrup_q = qrup.computeRrup(lon, lat, dep, var=True)
-    rrup_q = qrup.computeRrup(lon, lat, dep)
-    with pytest.raises(ValueError):
-        rjb_q = qrup.computeRjb(lon, lat, dep, var=True)
-    rjb_q = qrup.computeRjb(lon, lat, dep)
+    rrup_q, _ = qrup.computeRrup(lon, lat, dep)
+    rjb_q, _ = qrup.computeRjb(lon, lat, dep)
 
     # Construct equivalent EdgeRupture
     toplons = np.array([-122.0, -121.7, -122.5, -122.3])
@@ -362,12 +357,8 @@ def test_EdgeRupture_vs_QuadRupture():
     erup = EdgeRupture.fromArrays(
         toplons, toplats, topdeps, botlons, botlats, botdeps,
         origin, group_index)
-    with pytest.raises(ValueError):
-        rrup_e = erup.computeRrup(lon, lat, dep, var=True)
-    rrup_e = erup.computeRrup(lon, lat, dep)
-    with pytest.raises(ValueError):
-        rjb_e = erup.computeRjb(lon, lat, dep, var=True)
-    rjb_e = erup.computeRjb(lon, lat, dep)
+    rrup_e, _ = erup.computeRrup(lon, lat, dep)
+    rjb_e, _ = erup.computeRjb(lon, lat, dep)
 
     # Check that QuadRupture and EdgeRupture give the same result
     # (we check the absolute values of QuadRupture elsewhere)

--- a/tests/shakelib/rupture/rupture_test.py
+++ b/tests/shakelib/rupture/rupture_test.py
@@ -204,77 +204,77 @@ def test_rupture_from_dict():
     assert rup_original.getQuadrilaterals() is None
     assert rup_original.depths == 5.0
     # No mech, no tectonic region
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [41.11182253, 42.73956168])
     # Various combinations of mech and tectonic region...
     rup_original._origin._tectonic_region = 'Active Shallow Crust'
     rup_original._origin.mech = 'ALL'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [41.11182253, 42.73956168])
     rup_original._origin.mech = 'RS'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [39.17479645, 41.20916362])
     rup_original._origin.mech = 'NM'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [39.85641875, 41.89222387])
     rup_original._origin.mech = 'SS'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [43.21392667, 44.04215406])
     rup_original._origin._tectonic_region = 'Stable Shallow Crust'
     rup_original._origin.mech = 'ALL'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [42.68382206, 43.71213495])
     rup_original._origin.mech = 'RS'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [42.29766584, 43.51422441])
     rup_original._origin.mech = 'NM'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [42.57075149, 43.7987126])
     rup_original._origin.mech = 'SS'
-    rjb = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                  np.array([0.0]))
-    rrup = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                    np.array([0.0]))
+    rjb, _ = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
+                                     np.array([0.0]))
+    rrup, _ = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
+                                       np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [44.19126409, 45.02525107])
     rup_original._origin._tectonic_region = 'Somewhere Else'
     rup_original._origin.mech = 'ALL'
     rjb, var = rup_original.computeRjb(np.array([-122.0]), np.array([37.0]),
-                                       np.array([0.0]), var=True)
+                                       np.array([0.0]))
     rrup, var = rup_original.computeRrup(np.array([-122.0]), np.array([37.0]),
-                                         np.array([0.0]), var=True)
+                                         np.array([0.0]))
     np.testing.assert_allclose([rjb[0], rrup[0]],
                                [41.11182253, 42.73956168])
 
@@ -380,11 +380,11 @@ def test_EdgeRupture():
     lons = np.linspace(-120.1, -121.0, 10)
     lats = np.linspace(37.0, 38, 10)
     deps = np.zeros_like(lons)
-    rrup1 = qrup.computeRrup(lons, lats, deps)
-    rrup2 = erup.computeRrup(lons, lats, deps)
+    rrup1, _ = qrup.computeRrup(lons, lats, deps)
+    rrup2, _ = erup.computeRrup(lons, lats, deps)
     np.testing.assert_allclose(rrup1, rrup2, atol=2e-2)
-    rjb1 = qrup.computeRjb(lons, lats, deps)
-    rjb2 = erup.computeRjb(lons, lats, deps)
+    rjb1, _ = qrup.computeRjb(lons, lats, deps)
+    rjb2, _ = erup.computeRjb(lons, lats, deps)
     np.testing.assert_allclose(rjb1, rjb2, atol=2e-2)
     gc2 = erup.computeGC2(lons, lats, deps)
     targetRy0 = np.array(


### PR DESCRIPTION
  * Refactored multigmpe to use the additional variance from the
    point-source to finite rupture conversion (when applicable);
  * Revised model to use the raw GMPE uncertainty (i.e., not including
    the point-source correction) when computing the map grade
    (actually, it now uses the raw phi combined with the variance
    of the bias (which will be tau if there is no data, and zero if
    there is an infinite amount of data));
  * Refactored distance object and distance contexts to carry the
    additional point-source variance internally;
  * Revised modules and tests to handle the new data structures;
  * Added a new multigmpe test to compare the results of the new
    standard deviation calculation with a "hand" calculation;