### PR TITLE
Added sm_rupture program

### DIFF
--- a/bin/sm_rupture
+++ b/bin/sm_rupture
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+"""
+This is a utility program for creating ShakeMap 4 rupture.json files, either
+from a ShakeMap 3 style *_fault.txt file (and optionally an event.xml file),
+or the program will prompt you to manually input rupture data (strike, dip,
+length, ...).
+"""
+
+import argparse
+import numpy as np
+
+from shakelib.rupture.factory import get_rupture
+from shakelib.rupture.origin import Origin
+from shakelib.rupture.quad_rupture import QuadRupture
+
+
+# Lame method to detect integer using try block because
+# python doesn't have this basic function.
+def is_int(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+
+def is_float(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def prompt_user(args, origin):
+    n_quad = input('  - How many quadrilaterals are in this rupture? ')
+    if is_int(n_quad):
+        n_quad = int(n_quad)
+    else:
+        raise ValueError('Number of quadrilaterals must be an interger.')
+
+    px = []
+    py = []
+    pz = []
+    dx = []
+    dy = []
+    length = []
+    width = []
+    strike = []
+    dip = []
+    for i in range(n_quad):
+        print('  Quad %s of %s...' % (i+1, n_quad))
+
+        out = input('    Longitude of known point: ')
+        if is_float(out):
+            px.append(float(out))
+        else:
+            raise ValueError('Longitude of known point must be a float.')
+
+        out = input('    Latitude of known point: ')
+        if is_float(out):
+            py.append(float(out))
+        else:
+            raise ValueError('Latitude of known point must be a float.')
+
+        out = input('    Depth (km) of known point: ')
+        if is_float(out):
+            pz.append(float(out))
+        else:
+            raise ValueError('Depth of known point must be a float.')
+
+        out = input('    Along-strike distance (km) of known point: ')
+        if is_float(out):
+            dx.append(float(out))
+        else:
+            raise ValueError('Distance must be a float.')
+
+        out = input('    Along-dip distance (km) of known point: ')
+        if is_float(out):
+            dy.append(float(out))
+        else:
+            raise ValueError('Distance must be a float.')
+
+        out = input('    Length (km) of quadrilateral: ')
+        if is_float(out):
+            length.append(float(out))
+        else:
+            raise ValueError('Length must be a float.')
+
+        out = input('    Width (km) of quadrilateral: ')
+        if is_float(out):
+            width.append(float(out))
+        else:
+            raise ValueError('Width must be a float.')
+
+        out = input('    Strike (deg) of quadrilateral: ')
+        if is_float(out):
+            strike.append(float(out))
+        else:
+            raise ValueError('Strike must be a float.')
+
+        out = input('    Dip (deg) of quadrilateral: ')
+        if is_float(out):
+            dip.append(float(out))
+            print('*** DIP: %s ***' % out)
+        else:
+            raise ValueError('Dip must be a float.')
+
+    return QuadRupture.fromOrientation(
+        px, py, pz, dx, dy, length, width, strike, dip, origin
+    )
+
+
+def main(pparser, args):
+    """
+    Args:
+        pparser: ArgumentParser object.
+        args: ArgumentParser namespace with command line arguments.
+    """
+    # First deal with origin
+    if args.eventfile:
+        origin = Origin.fromFile(args.eventfile)
+    else:
+        print("* No event.xml file specified, using dummy origin...")
+        dummy = {
+            'mag': np.nan,
+            'id': 'dummy',
+            'locstring': 'dummy',
+            'mech': 'ALL',
+            'lon': np.nan,
+            'lat': np.nan,
+            'depth': np.nan,
+            'netid': "",
+            'network': "",
+            'time': ""
+        }
+        origin = Origin(dummy)
+
+    # Was a fault file given?
+    if args.file:
+        # User provided fault.txt file
+        rup = get_rupture(origin, file=args.file, new_format=not args.old)
+    else:
+        # User did not provide fault.txt file
+        explain_text = '''
+* No fault file specified. You will be prompted to manually enter rupture
+information.
+
+You will need to specify the number of quadrilaterals in the rupture. Each
+quadrilateral will be defined with the following geometry:
+
+                            strike direction
+                        p1*------------------->>p2
+                        *        | dy           |
+                 dip    |--------o              |
+              direction |   dx    known point   | Width
+                        V                       |
+                        V                       |
+                        p4----------------------p3
+                                Length
+'''
+        print(explain_text)
+        rup = prompt_user(args, origin)
+
+    # Write output
+    rup.writeGeoJson(args.outfile)
+
+
+def get_parser():
+    desc = '''Create a ShakeMap 4 Rupture File.
+
+This program creates a ShakeMap 4 rupture file. If a ShakeMap 3 *_fault.txt
+file is provided, it will try to convert it to a rupture.json file. Otherwise,
+the user will be prompted to manually input rupture data (strike, dip, ...).
+
+Note that the rupture.json requires some origin information that is not in
+the fault.txt file and so these values are filled in with empty values unless
+an event.xml file is also provided.
+'''
+    parser = argparse.ArgumentParser(description=desc, epilog='\n\n')
+    parser.add_argument(
+        'outfile',
+        help='Path for output rupture file.')
+    parser.add_argument(
+        '-f', '--file', type=str,
+        help='Path to ShakeMap 3 fault file.')
+    parser.add_argument(
+        '-e', '--eventfile', type=str,
+        help='Path to an event.xml file.')
+    parser.add_argument(
+        '-o', '--old', action='store_true',
+        help='Indicates that the ShakeMap 3 fault file'
+             'uses the old format (ordering lon before '
+             'lat).')
+    return parser
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    main(parser, args)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(name='shakemap',
           'bin/sm_migrate',
           'bin/sm_profile',
           'bin/sm_compare',
-          'bin/sm_queue'
+          'bin/sm_queue',
+          'bin/sm_rupture'
       ],
       )

--- a/shakelib/rupture/quad_rupture.py
+++ b/shakelib/rupture/quad_rupture.py
@@ -496,7 +496,7 @@ class QuadRupture(Rupture):
         dip = np.array(dip, dtype='d')
 
         # Get P1 and P2 (top horizontal points)
-        theta = np.rad2deg(np.arctan((dy * np.cos(np.deg2rad(dip))) / dx))
+        theta = np.rad2deg(np.arctan2(dy * np.cos(np.deg2rad(dip)), dx))
         P1_direction = strike + 180 + theta
         P1_distance = np.sqrt(dx**2 + (dy * np.cos(np.deg2rad(dip)))**2)
         P2_direction = strike

--- a/tests/shakemap/programs/sm_rupture_test.py
+++ b/tests/shakemap/programs/sm_rupture_test.py
@@ -1,0 +1,89 @@
+
+import os
+import subprocess
+import tempfile
+
+import numpy as np
+
+from shakelib.rupture.factory import get_rupture
+from shakelib.rupture.origin import Origin
+
+
+homedir = os.path.dirname(os.path.abspath(__file__))
+shakedir = os.path.abspath(os.path.join(homedir, '..', '..', '..'))
+
+# Dummy origin
+dummy = {
+    'mag': np.nan,
+    'id': 'dummy',
+    'locstring': 'dummy',
+    'mech': 'ALL',
+    'lon': np.nan,
+    'lat': np.nan,
+    'depth': np.nan,
+    'netid': "",
+    'network': "",
+    'time': ""
+}
+origin = Origin(dummy)
+
+program = os.path.join(shakedir, 'bin', 'sm_rupture')
+
+
+def test_rupture():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Read in a fault file
+        rup1_file = os.path.join(
+            shakedir, 'tests', 'data', 'eventdata', 'northridge', 'current',
+            'northridge_fault.txt')
+        rup1 = get_rupture(origin, rup1_file)
+
+        # Known point is p0
+        dx = 0
+        dy = 0
+        p0 = rup1.getQuadrilaterals()[0][0]
+        px = p0.x
+        py = p0.y
+        pz = p0.z
+        length = rup1.getLength()
+        width = rup1.getWidth()
+        strike = rup1.getStrike()
+        dip = rup1.getDip()
+
+        outfile = os.path.join(tmpdir, 'test.json')
+
+        op = subprocess.Popen(
+            [program, outfile],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False
+        )
+        responses = (
+            '1\n' +
+            str(px) + '\n' +
+            str(py) + '\n' +
+            str(pz) + '\n' +
+            str(dx) + '\n' +
+            str(dy) + '\n' +
+            str(length) + '\n' +
+            str(width) + '\n' +
+            str(strike) + '\n' +
+            str(dip) + '\n'
+        )
+        op.communicate(responses.encode('ascii'))
+        rup2 = get_rupture(origin, outfile)
+
+        # testing, note that some difference will occur since the original
+        # points are not necessarily coplanar or even rectangular, which
+        # are conditions enfored on the derived rupture and so this cannot
+        # be a very precise comparison.
+        rtol = 1e-4
+        np.testing.assert_allclose(rup2.lats, rup1.lats, rtol=rtol)
+        np.testing.assert_allclose(rup2.lons, rup1.lons, rtol=rtol)
+        rtol = 2e-3
+        np.testing.assert_allclose(rup2.depths, rup1.depths, rtol=rtol)
+
+
+if __name__ == '__main__':
+    test_rupture()


### PR DESCRIPTION
Closes #757 and minimally closes #532. This converts a text file to rupture.json if it is provided. This should be how complex faults are specified (many quads, complicated geometry, etc.). But for simple faults, perhaps from papers where things like strike/dip/length/width are provided, it prompts the user to enter those values if a fault.txt file is not provided. An additional complication is that rupture.json includes some origin information that has never been present in fault.txt. So there is an option to specify an event.xml file to fill in that info. If it is not provided then it is filled in with blanks that can then be edited by hand. 