### PR TITLE
Sub

### DIFF
--- a/tests/shakemap/utils/probs_test.py
+++ b/tests/shakemap/utils/probs_test.py
@@ -109,10 +109,9 @@ def test_probs():
 
     org.depth = 20.0
     gmmodel, strec_results = get_weights(org, config)
-    assert np.allclose(gmmodel['weightlist'], [0.63, 0.3, 0.07])
+    assert np.allclose(gmmodel['weightlist'], [0.7, 0.3])
     assert gmmodel['gmpelist'] == ['subduction_crustal',
-                                   'subduction_interface_nshmp2014',
-                                   'subduction_slab_nshmp2014']
+                                   'subduction_interface_nshmp2014']
     assert gmmodel['ipe'] == 'VirtualIPE'
     assert gmmodel['gmice'] == 'WGRW12'
     assert gmmodel['ccf'] == 'LB13'


### PR DESCRIPTION
There was a problem in the way select behaves within subduction zones in locations where the slab model is not defined (this is a pretty limited area). The problem was that it was using the parameters that were meant for tapers related to the slab model to define the crustal probabilities. This was confusing and so I changed it to be simpler and give more intuitive results. Prior to this, there was an unintended (but small) probability of slab at shallow depths (<~28 km). See plot for the profile of crustal, slab, and interface probabilities now that this is fixed. 
![sub_no_slab](https://user-images.githubusercontent.com/15928870/45121438-623b7880-b11e-11e8-9a4e-6725fde01d86.png)
