### PR TITLE
Revised the subduction_interface_nshmpo2014 gmpe set to remove AM09

### DIFF
--- a/shakemap/data/gmpe_sets.conf
+++ b/shakemap/data/gmpe_sets.conf
@@ -144,9 +144,14 @@
         site_gmpes = Akea14, Cau14, CY14
         weights_site_gmpes = 0.33, 0.33, 0.34
 
+# The NSHMP subduction interface relation should really be:
+#        gmpes = AB03i, Zea16i, AM09, Aea15i
+#        weights = 0.1, 0.3, 0.3, 0.3
+# but AM09 behaves badly at lower magnitudes, so we exclude it until
+# we build in magnitude dependence
     [[subduction_interface_nshmp2014]]
-        gmpes = AB03i, Zea16i, AM09, Aea15i
-        weights = 0.1, 0.3, 0.3, 0.3
+        gmpes = AB03i, Zea16i, Aea15i
+        weights = 0.2, 0.4, 0.4
         site_gmpes = Aea15i, AB03i
         weights_site_gmpes = 0.5, 0.5
     [[subduction_interface_share]]


### PR DESCRIPTION
since it behaves badly for smaller magnitude events.