### PR TITLE
Extent tweaks

### DIFF
--- a/shakelib/utils/utils.py
+++ b/shakelib/utils/utils.py
@@ -176,6 +176,19 @@ def get_extent(rupture=None, config=None):
         gmpe = MultiGMPE.from_config(config)
         gmice = get_object_from_config('gmice', 'modeling', config)
     else:
+        # Put in some default values for conf
+        config = {
+            'extent': {
+                'mmi': {
+                    'threshold': 4.5,
+                    'mindist': 100,
+                    'maxdist': 1000
+                }
+            }
+        }
+
+        # Generic GMPEs choices based only on active vs stable
+        # as defaults...
         stable = is_stable(origin.lon, origin.lat)
         if not stable:
             ASK14 = AbrahamsonEtAl2014()
@@ -200,10 +213,11 @@ def get_extent(rupture=None, config=None):
             site_gmpes = [AB06p]
             weights = [0.16, 0.0, 0.0, 0.17, 0.17, 0.3, 0.2, 0.0, 0.0]
             gmice = AK07()
+
         gmpe = MultiGMPE.from_list(
             gmpes, weights, default_gmpes_for_site=site_gmpes)
 
-    min_mmi = 5.0
+    min_mmi = config['extent']['mmi']['threshold']
     default_imt = imt.SA(1.0)
     sd_types = [const.StdDev.TOTAL]
 
@@ -211,8 +225,8 @@ def get_extent(rupture=None, config=None):
     dx = DistancesContext()
     # This imposes minimum/ maximum distances of:
     #   80 and 800 km; could make this configurable
-    d_min = 80
-    d_max = 800
+    d_min = config['extent']['mmi']['mindist']
+    d_max = config['extent']['mmi']['maxdist']
     dx.rjb = np.logspace(np.log10(d_min), np.log10(d_max), 2000)
     # Details don't matter for this; assuming vertical surface rupturing fault
     # with epicenter at the surface.

--- a/shakemap/data/model.conf
+++ b/shakemap/data/model.conf
@@ -223,8 +223,8 @@
     # order of priority: bounds, magnitude_spans, coefficients.
 
     # If neither of these options are specified, ShakeMap will use the GMPE/GMICE
-    # used to construct the map to get an estimate of the extent that will include
-    # all locations that exceed MMI 4.
+    # to get an estimate of the extent that will include all locations that exceed
+    # the configured MMI threshold.
 
     [[magnitude_spans]]
         #-----------------------------------------------------------------------
@@ -250,5 +250,16 @@
         # Example:
         # extent = -151.0, 60.5, -148.5, 62.5
         #-----------------------------------------------------------------------
-        
+
+    [[mmi]]
+	# Threshold MMI to ensure is included in the extent of the map:
+	threshold=4.5
+	# Minimum distance (km) away from the origin for the extent; mindist
+	# will take precidence over the MMI threshold so that tiny maps are not
+	# created for small magnitude events.
+	mindist=100
+	# Maximum distance (km) away from the origin for the extent; maxdist
+	# will prevent extents from getting too large for large magnitude events.
+	maxdist=1000
+
 # End [extent]

--- a/shakemap/data/modelspec.conf
+++ b/shakemap/data/modelspec.conf
@@ -78,6 +78,9 @@
         
     [[bounds]]
         extent = float_list(default = list(-999.0,-999.0,-999.0,-999.0))
-        
+    [[mmi]]
+	threshold=float(min=1, default=4.5)
+	mindist=float(min=0, default=100)
+	maxdist=float(min=0, default=1000)
 # End [extent]
 

--- a/tests/shakelib/utils/utils_test.py
+++ b/tests/shakelib/utils/utils_test.py
@@ -66,10 +66,10 @@ def test_get_extent_small_point():
     origin = Origin.fromFile(eventfile)
     rupture = get_rupture(origin)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 102.53333333333333)
-    np.testing.assert_allclose(E, 104.2)
-    np.testing.assert_allclose(S, 30.266666666666666)
-    np.testing.assert_allclose(N, 31.7)
+    np.testing.assert_allclose(W, 102.33333333333333)
+    np.testing.assert_allclose(E, 104.41666666666667)
+    np.testing.assert_allclose(S, 30.083333333333332)
+    np.testing.assert_allclose(N, 31.883333333333333)
 
 
 def test_get_extent_small_complex():
@@ -81,10 +81,10 @@ def test_get_extent_small_complex():
     faultfile = os.path.join(datadir, 'Hartzell11_fault.txt')
     rupture = get_rupture(origin, faultfile)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 97.45)
-    np.testing.assert_allclose(E, 112.13333333333333)
-    np.testing.assert_allclose(S, 25.35)
-    np.testing.assert_allclose(N, 37.833333333333336)
+    np.testing.assert_allclose(W, 95.28333333333333)
+    np.testing.assert_allclose(E, 115.1)
+    np.testing.assert_allclose(S, 23.083333333333332)
+    np.testing.assert_allclose(N, 39.75)
 
 
 def test_get_extent_bad_usage():
@@ -117,10 +117,10 @@ def test_get_extent_aspect():
     )
     rupture = get_rupture(origin, rrep)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 94.78333333333333)
-    np.testing.assert_allclose(E, 116.96666666666667)
-    np.testing.assert_allclose(S, 21.78333333333333)
-    np.testing.assert_allclose(N, 37.46666666666667)
+    np.testing.assert_allclose(W, 92.65)
+    np.testing.assert_allclose(E, 119.98333333333333)
+    np.testing.assert_allclose(S, 19.833333333333332)
+    np.testing.assert_allclose(N, 38.96666666666667)
     #
     # Long vertical rupture
     #
@@ -135,10 +135,10 @@ def test_get_extent_aspect():
     )
     rupture = get_rupture(origin, rrep)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 90.2)
-    np.testing.assert_allclose(E, 112.28333333333333)
-    np.testing.assert_allclose(S, 18.4)
-    np.testing.assert_allclose(N, 40.68333333333333)
+    np.testing.assert_allclose(W, 88.48333333333333)
+    np.testing.assert_allclose(E, 115.08333333333333)
+    np.testing.assert_allclose(S, 16.1)
+    np.testing.assert_allclose(N, 42.583333333333336)
 
 
 def test_get_extent_stable_small():
@@ -150,10 +150,10 @@ def test_get_extent_stable_small():
     origin = Origin.fromFile(eventfile)
     rupture = get_rupture(origin)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, -98.28333333333333)
-    np.testing.assert_allclose(E, -96.5)
-    np.testing.assert_allclose(S, 34.95)
-    np.testing.assert_allclose(N, 36.4)
+    np.testing.assert_allclose(W, -98.5)
+    np.testing.assert_allclose(E, -96.28333333333333)
+    np.testing.assert_allclose(S, 34.766666666666666)
+    np.testing.assert_allclose(N, 36.583333333333336)
 
 
 def test_get_extent_stable_large():
@@ -165,10 +165,10 @@ def test_get_extent_stable_large():
     origin = Origin.fromFile(eventfile)
     rupture = get_rupture(origin)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, -105.56666666666666)
-    np.testing.assert_allclose(E, -87.61666666666666)
-    np.testing.assert_allclose(S, 28.15)
-    np.testing.assert_allclose(N, 42.55)
+    np.testing.assert_allclose(W, -107.45)
+    np.testing.assert_allclose(E, -84.8)
+    np.testing.assert_allclose(S, 26.166666666666668)
+    np.testing.assert_allclose(N, 44.15)
 
 
 def test_is_stable():


### PR DESCRIPTION
Additional tweaks to get_extent:
- Made the MMI-based extent option configurable with the mmi threshold, mindist, and maxdist parameters. 
- Changed the default values so that we will get larger extents because it seems that the prior change that decreased the extent was a bit of an over correction. 