### PR TITLE
Fix contour labels for very small values

### DIFF
--- a/shakemap/mapping/mapmaker.py
+++ b/shakemap/mapping/mapmaker.py
@@ -1237,7 +1237,12 @@ def draw_map(adict, override_scenario=False):
                         continue
                     # TODO: figure out if box is going to go outside the map,
                     # if so choose a different point on the line.
-                    ax.text(xc, yc, '%.1f' % props['value'], size=8,
+
+                    # For small values, use scientific notation with 1 sig fig
+                    # to avoid multiple contours labelled 0.0:
+                    value = props['value']
+                    fmt = '%.1g' if abs(value) < 0.1 else '%.1f'
+                    ax.text(xc, yc, fmt % value, size=8,
                             ha="center", va="center",
                             bbox=white_box, zorder=AXES_ZORDER-1)
 


### PR DESCRIPTION
For very small events, the contour maps produced by shakemap.mapping.mapmaker sometimes have multiple contours labelled 0.0 or 0.1:
![before_psa3p0](https://user-images.githubusercontent.com/58440/62668285-b144fa00-b9ce-11e9-9250-766e716d624e.jpg)

This PR is a very small patch that switches the label formatting to scientific notation for small values, resulting in this instead:
![after_psa3p0](https://user-images.githubusercontent.com/58440/62668286-b2762700-b9ce-11e9-96a4-9785caab6efa.jpg)
