### PR TITLE
Some cosmetic options

### DIFF
--- a/shakemap/data/mapping/map_strings.en-AU
+++ b/shakemap/data/mapping/map_strings.en-AU
@@ -1,0 +1,119 @@
+// To adapt ShakeMap to a particular language, copy this file to a file
+// with the proper extension, then edit the text as needed. This file
+// will be read as UTF-8 and should therefore handle most character sets.
+// In general, edit only the values, not the keys in the data structure
+// below. E.g.:
+//  {
+//      key: value,
+//      key: {
+//          key: value,
+//          key: value,
+//          key: value
+//      },
+//      key: [
+//          value, value, value, value
+//      }
+//      key: {
+//          key: [
+//              value,
+//              value,
+//              value,
+//              value
+//          ],
+//          key: {
+//              key: value,
+//              key: value,
+//              key: value
+//          }
+//      }
+//  }
+//
+// You may need to add additionaly entries to some of these structures
+// if you add new intensity measure (IM) types.
+// When making the intensity scale, the "box_widths" are set to accommodate
+// the text that goes into them. If your text needs more or less room, you
+// can adjust these numbers, but the numbers must add up to 100.
+// All of the keys defined herein must remain even if the translation is
+// the English default.
+// The 'date_format' in 'title_parts' must be a valid Python datetime
+// strftime() format. It will behave according to the user's LOCALE setting,
+// so it should be tested in the ShakeMap execution environment before
+// committing to production.
+{
+    "IMTYPES": {
+        "MMI": "Macroseismic Intensity Map",
+        "PGV": "Peak Ground Velocity Map",
+        "PGA": "Peak Ground Acceleration Map",
+        "SA(0.3)": "0.3 Second Peak Spectral Acceleration Map",
+        "SA(1.0)": "1.0 Second Peak Spectral Acceleration Map",
+        "SA(3.0)": "3.0 Second Peak Spectral Acceleration Map"
+    },
+    "units": {
+         "PGV": "(cm/s)",
+         "PGA": "(%g)",
+         "SA(0.3)": "(%g)",
+         "SA(1.0)": "(%g)",
+         "SA(3.0)": "(%g)"
+    },
+    "legend": {
+        "instrument": "Seismic Instrument",
+        "intensity": "Reported Intensity",
+        "epicenter": "Epicenter",
+        "rupture": "Rupture",
+        "version": "Version",
+        "processed": "Processed",
+        "scale": "Scale based on"
+    },
+    "mmi_scale": {
+        "shaking_labels": [
+            "SHAKING",
+            "Not felt",
+            "Weak",
+            "Light",
+            "Moderate",
+            "Strong",
+            "Very strong",
+            "Severe",
+            "Violent",
+            "Extreme"
+        ],
+        "damage_labels": [
+            "DAMAGE",
+            "None",
+            "None",
+            "None",
+            "Very light",
+            "Light",
+            "Moderate",
+            "Moderate/heavy",
+            "Heavy",
+            "Very heavy"
+        ],
+        "acc_label": "PGA(%g)",
+        "vel_label": "PGV(cm/s)",
+        "intensity_labels": [
+            "INTENSITY", "I", "II-III",
+            "IV", "V", "VI", "VII", "VIII", "IX", "X+"
+        ],
+        "box_widths": [ 
+            11.5, 7.75, 6.75, 7.0, 10.25, 8.5, 12.0, 16.25, 8.25, 11.75
+        ],
+        "mmi_colorbar_labels": [
+            "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"
+        ]
+    },
+    "title_parts": {
+        "shakemap": "ShakeMap",
+        "depth": "Depth",
+        "depth_units": "km",
+        "timezone": "UTC",
+        "magnitude": "M",
+        "event_id": "ID",
+        "scenario": "SCENARIO",
+        "north": "N",
+        "south": "S",
+        "east": "E",
+        "west": "W",
+        "date_format": "%d %b %Y %H:%M:%S"
+    }
+}

--- a/shakemap/mapping/mapmaker.py
+++ b/shakemap/mapping/mapmaker.py
@@ -847,7 +847,9 @@ def _draw_title(imt, adict):
         etime = datetime.strptime(edict['origin_time'],
                                   constants.ALT_TIMEFMT)
     timestr = etime.strftime(tdict['title_parts']['date_format'])
-    mag = float(edict['magnitude'])
+    mag = adict.get('display_magnitude')
+    if mag is None:
+        mag = float(edict['magnitude'])
     if hlon < 0:
         lonstr = '%s%.2f' % (tdict['title_parts']['west'], np.abs(hlon))
     else:


### PR DESCRIPTION
While configuring shakemap's maps to satisfy our requirements at GA, there were a couple of things that weren't possible without some small modifications to the codebase.

- Added an en-AU language definition, which for now is simply a copy of the default en language but with dd mm yyyy date format.
- Added the option `--display-magnitude` to `shakemap.coremods.mapping`, which changes the magnitude displayed in the header of the map products. We need this because our official published magnitudes are often in scales other than Mw, so we need to feed an Mw magnitude to shakemap's model while displaying our official magnitude for consistency.