### PR TITLE
Fix shape module to handle missing values

### DIFF
--- a/shakemap/coremods/shape.py
+++ b/shakemap/coremods/shape.py
@@ -123,14 +123,14 @@ def create_polygons(container, datadir, logger, max_workers):
                 fname = 'mi'
             elif imt == 'PGV':
                 fgrid = np.exp(fgrid)
-                cont_max = np.ceil(np.max(fgrid)) + 2.0
+                cont_max = np.ceil(np.nanmax(fgrid)) + 2.0
                 contour_levels = np.arange(1.0, cont_max, 2.0)
                 if contour_levels.size == 0:
                     contour_levels = np.array([1.0])
                 fname = 'pgv'
             else:
                 fgrid = np.exp(fgrid)
-                cont_max = (np.ceil(100 * np.max(fgrid)) + 2.0) / 100.0
+                cont_max = (np.ceil(100 * np.nanmax(fgrid)) + 2.0) / 100.0
                 contour_levels = np.arange(0.01, cont_max, 0.02)
                 if contour_levels.size == 0:
                     contour_levels = np.array([0.01])


### PR DESCRIPTION
Masked IMT grids produced by using the option I added in #1011 will currently cause the `shape` module to fail due to not handling NANs when choosing contour levels.

This simple patch at least fixes the crash. Looks like the NANs are replaced with 0s in `contour.c`, so the output isn't exactly correct, but it's not horrible - all contour lines that hit the mask boundary end up tracing along it.