### PR TITLE
Reduce unnecessary RAM usage in mapping

### DIFF
--- a/shakemap/coremods/mapping.py
+++ b/shakemap/coremods/mapping.py
@@ -381,6 +381,7 @@ def make_map(adict):
         fig2.gca().xaxis.set_major_locator(NullLocator())
         fig2.gca().yaxis.set_major_locator(NullLocator())
         fig2.savefig(legend_file, bbox_inches='tight', pad_inches=0)
+        plt.close(fig2)
     else:
         fileimt = oq_to_file(imtype)
         pdf_file = os.path.join(adict['datadir'], '%s.pdf' % (fileimt))
@@ -388,6 +389,7 @@ def make_map(adict):
 
     fig1.savefig(pdf_file, bbox_inches='tight', dpi=adict['pdf_dpi'])
     fig1.savefig(jpg_file, bbox_inches='tight', dpi=adict['img_dpi'])
+    plt.close(fig1)
 
 
 def make_pin_thumbnail(adict):

--- a/shakemap/mapping/mapmaker.py
+++ b/shakemap/mapping/mapmaker.py
@@ -818,10 +818,13 @@ def _get_shaded(ptopo, contour_colormap):
         intensity1 = ls1.hillshade(ptopo, fraction=0.25, vert_exag=VERT_EXAG)
         intensity2 = ls2.hillshade(ptopo, fraction=0.25, vert_exag=VERT_EXAG)
         intensity = intensity1 * 0.5 + intensity2 * 0.5
+        del intensity1, intensity2
 
     ptoposc = ptopo / maxvalue
     rgba = contour_colormap.cmap(ptoposc)
+    del ptoposc
     rgb = np.squeeze(rgba)
+    del rgba
 
     draped_hsv = ls1.blend_hsv(rgb, np.expand_dims(intensity, 2))
 
@@ -1006,7 +1009,9 @@ def _get_draped(data, topodata, colormap):
     maxvalue = colormap.vmax
     mmisc = data / maxvalue
     rgba_img = colormap.cmap(mmisc)
+    del mmisc
     rgb = np.squeeze(rgba_img[:, :, 0:3])
+    del rgba_img
 
     if np.allclose(topodata, 0):
         intensity = np.full_like(topodata, 0.5)
@@ -1019,6 +1024,7 @@ def _get_draped(data, topodata, colormap):
         intensity2 = ls2.hillshade(
             topodata, fraction=0.25, vert_exag=VERT_EXAG)
         intensity = intensity1 * 0.5 + intensity2 * 0.5
+    del intensity1, intensity2
 
     ls = LightSource(azdeg=315, altdeg=45)
     draped_hsv = ls.blend_hsv(rgb, np.expand_dims(intensity, 2))


### PR DESCRIPTION
When using a large spatial extent, the topography raster data causes the `mapping` module to use a lot of memory. This PR alleviates this in a couple of ways:

- pyplot figures are explicitly closed after rendering, which avoids all plots being kept in memory for the whole process. (Only really noticable for a small value of max_workers).
- Some large intermediate variables are deleted to free their memory earlier.

Before:
![no_optimizations](https://user-images.githubusercontent.com/58440/67056786-4e739a00-f199-11e9-8132-b051ea10c14c.png)
After:
![all_optimizations](https://user-images.githubusercontent.com/58440/67056788-4f0c3080-f199-11e9-980b-7c84df36445b.png)

