### PR TITLE
Contour nan fixes

### DIFF
--- a/shakelib/plotting/contour.py
+++ b/shakelib/plotting/contour.py
@@ -57,12 +57,15 @@ def contour(imtdict, imtype, filter_size, gmice):
     if imtype == 'MMI':
         interval_type = 'linear'
 
-    grid_min = np.nanmin(fgrid)
-    grid_max = np.nanmax(fgrid)
-    if grid_max - grid_min:
-        intervals = getContourLevels(grid_min, grid_max, itype=interval_type)
-    else:
+    if np.all(np.isnan(fgrid)): # data is totally empty; no contours
         intervals = np.array([])
+    else:
+        grid_min = np.nanmin(fgrid)
+        grid_max = np.nanmax(fgrid)
+        if grid_max - grid_min:
+            intervals = getContourLevels(grid_min, grid_max, itype=interval_type)
+        else: # data is totally flat; don't draw any contours
+            intervals = np.array([])
 
     lonstart = metadata['xmin']
     latstart = metadata['ymin']

--- a/shakemap/coremods/mapping.py
+++ b/shakemap/coremods/mapping.py
@@ -400,7 +400,7 @@ def make_pin_thumbnail(adict):
     """Make the artsy-thumbnail for the pin on the USGS webpages.
     """
     imtdict = adict['imtdict']
-    grid = np.nan_to_num(imtdict['mean'], nan=0.0)
+    grid = np.nan_to_num(imtdict['mean'])
     metadata = imtdict['mean_metadata']
     num_pixels = 300
     randx = np.random.rand(num_pixels)
@@ -475,7 +475,7 @@ def make_overlay(adict):
         nothing: Nothing.
     """
     mmidict = adict['imtdict']
-    mmi_array = np.nan_to_num(mmidict['mean'], nan=0.0)
+    mmi_array = np.nan_to_num(mmidict['mean'])
     geodict = GeoDict(mmidict['mean_metadata'])
     palette = ColorPalette.fromPreset('mmi')
     mmi_rgb = palette.getDataColor(mmi_array, color_format='array')

--- a/shakemap/data/products.conf
+++ b/shakemap/data/products.conf
@@ -172,3 +172,21 @@
     #########################################################################
     [[[ layers ]]]
       topography = <DATA_DIR>/topo/topo_30sec.grd
+  ###########################################################################
+  # The shape module makes shapefiles containing contour maps.
+  ###########################################################################
+  [[ shape ]]
+    #########################################################################
+    # method: either 'pcontour' or 'skimage', default 'pcontour'.
+    #
+    # This determines which of the two contour map implementations are used:
+    # the built-in pcontour (which generates a finely detailed map) or
+    # the marching squares implementation from scikit-image followed up by 
+    # a smoothing filter, which is the same method used to generate the
+    # contours in the mapping and contour modules.
+    #
+    # NOTE: The pcontour method does not correctly handle missing data; so if
+    # you're using a maskfile in your model configuration and you want 
+    # shapefile outputs, you should set this to skimage.
+    #########################################################################
+    method = 'pcontour'

--- a/shakemap/data/productsspec.conf
+++ b/shakemap/data/productsspec.conf
@@ -22,4 +22,5 @@
       faultwidth = float(min=0, default=0.75)
       roadcolor = string(default='dimgray')
       roadwidth = float(min=0, default=1.0)
-    
+  [[shape]]
+    method = option('pcontour', 'skimage', default='pcontour')


### PR DESCRIPTION
This PR is a follow up to #1011 and #1016 which fixes a few deficiencies:

* When IMT output grids are completely blank (NaN) as a result of polygon masking, all contour-based products would fail to render. They now will be rendered with no contours (as in the case of an output grid that is constant).
* Fixes #1017 by not passing unnecessary numpy-1.17-specific arguments.  (b873384 corrected one instance of this, but not all three.)
* Added a `method` option to products.conf that makes the `shape` module use the same contour generation code as the `contour` and `mapping` modules, which knows how to handle missing data. (I left the default as `pcontour`, so shouldn't break anything for anyone.)