### PR TITLE
Add the (optional) cancel_subject and cancel_message parameters to the

### DIFF
--- a/shakemap/data/transfer.conf
+++ b/shakemap/data/transfer.conf
@@ -107,7 +107,17 @@
 # - subject: The desired subject line (see macros list above).
 # - attachments: The list (comma separated) of product files that should be
 #                attached to the email.
-# - message: The desired message body (see macros list above).
+# - message: The desired message body (see macros list above). This may be
+#            a multi-line message enclosed in triple quotes:
+#            """<multi-line message"""
+#            See example below.
+# - cancel_subject: The subject line for cancellation messages (see macros
+#                   list above).
+# - cancel_message: The message body for cancellation messages (see macros
+#                   list above). This may be a multi-line message enclosed
+#                   in triple quotes:
+#                   """<multi-line message"""
+#                   See example below.
 #---------------------------------------------------------------------------      
 
 # A sample email configuration is included below.  Modify the parameters described
@@ -121,22 +131,34 @@
 #     subject = "M[MAG] earthquake in [LOC]"
 #     attachments = intensity.jpg
 #     message = """A ShakeMap has been produced for event [EVENTID].
-
+#
 # PRELIMINARY EARTHQUAKE SUMMARY:
 # DATE: [DATE]
 # TIME: [TIME]
 # LOCATION: [LOC]
 # MAGNITUDE: [MAG]
-
+#
 # The US Geological Survey has posted a ShakeMap for the above earthquake at:
-
-
+#
+#
 # http://earthquake.usgs.gov/earthquakes/eventpage/[EVENTID]#shakemap
-
+#
 # This ShakeMap was automatically generated; it is preliminary, subject to
 # change, and may contain inaccuracies.  ShakeMaps are updated as additional
 # information becomes available. To view updates please visit the URL listed
 # above.  You may need to use your browser's 'Reload' button to see updated
 # maps.
-
+#
 # For additional information, please check http://earthquake.usgs.gov."""
+#
+#     cancel_subject = "ShakeMap for event [EVENTID] has been canceled"
+#     cancel_message = """The ShakeMap for event [EVENTID] has been canceled
+# by the network operator.
+#
+# DATE: [DATE]
+# TIME: [TIME]
+# LOCATION: [LOC]
+#
+# The event may have been mis-identified, or it may have been incorporated
+# into another event. Please check the website for current event information:
+# https://www.usgs.gov/natural-hazards/earthquake-hazards/earthquakes"""

--- a/shakemap/data/transferspec.conf
+++ b/shakemap/data/transferspec.conf
@@ -22,3 +22,5 @@
     subject = string()
     attachments = force_list(default=list())
     message = string()
+    cancel_subject = string()
+    cancel_message = string()


### PR DESCRIPTION
email messages in transfer as requested by Gary Gann.