### PR TITLE
Scenarios

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,7 @@ dev_list=(
 package_list=(
       "python=$py_ver"
       "$CC_PKG"
-      "cartopy"
+      "cartopy>=0.18"
       "cython"
       "defusedxml"
       "descartes"

--- a/shakemap/mapping/mapmaker.py
+++ b/shakemap/mapping/mapmaker.py
@@ -804,6 +804,8 @@ def _draw_graticules(adict, ax, xmin, xmax, ymin, ymax):
     gl.left_labels = True
     gl.right_labels = False
     gl.xlines = True
+    gl.xlabels_top = False
+    gl.ylabels_right = False
 
     # create a dictionary with the intervals we want for a span
     # of degrees.
@@ -929,7 +931,7 @@ def _draw_title(imt, adict, uncertainty=False):
         imtstr = period + tdict['IMTYPES']['SA']
     else:
         imtstr = tdict['IMTYPES'][imt]
-    if len(eid) <= 10:
+    if len(eid) <= 20:
         fmt = ('%s %s\n%s %s: %s\n %s %s %s%.1f %s %s '
                '%s: %.1f%s %s:%s')
     else:
@@ -1199,8 +1201,8 @@ def draw_map(adict, override_scenario=False):
     # Retrieve the epicenter - this will get used on the map
     rupture = rupture_from_dict(adict['ruptdict'])
     origin = rupture.getOrigin()
-    center_lat = origin.lat
-    center_lon = origin.lon
+    epi_lat = origin.lat
+    epi_lon = origin.lon
 
     # load the cities data, limit to cities within shakemap bounds
     cities = adict['allcities'].limitByBounds((gd.xmin, gd.xmax,
@@ -1208,6 +1210,8 @@ def draw_map(adict, override_scenario=False):
 
     # get the map boundaries and figure size
     bounds, figsize, aspect = _get_map_info(gd)
+    center_lat = np.mean(bounds[2:4])
+    center_lon = np.mean(bounds[0:2])
 
     # Note: dimensions are: [left, bottom, width, height]
     dim_left = 0.1
@@ -1440,7 +1444,7 @@ def draw_map(adict, override_scenario=False):
 
     # Draw the epicenter as a black star
     plt.sca(ax)
-    plt.plot(center_lon, center_lat, 'k*', markersize=16,
+    plt.plot(epi_lon, epi_lat, 'k*', markersize=16,
              zorder=EPICENTER_ZORDER, transform=geoproj)
 
     # draw the rupture polygon(s) in black, if not point rupture

--- a/shakemap/mapping/mapmaker.py
+++ b/shakemap/mapping/mapmaker.py
@@ -804,8 +804,6 @@ def _draw_graticules(adict, ax, xmin, xmax, ymin, ymax):
     gl.left_labels = True
     gl.right_labels = False
     gl.xlines = True
-    gl.xlabels_top = False
-    gl.ylabels_right = False
 
     # create a dictionary with the intervals we want for a span
     # of degrees.


### PR DESCRIPTION
- The primary thing here is to fix the "scenario" splash on the maps to always be centered. Previously it was centered on the epicenter, which looks bad if the map is not centered on the epicenter. 
- Also, even when I installed a fresh virtual environment, I still got cartopy v0.17. This caused extra axis labels (top and right) that collided with the map title. This is because of a change in how gridlines work between the versions. So I changed the install.sh script to require cartopy 0.18 or new. 