### PR TITLE
Update transfer configurations for scp remote port 

### DIFF
--- a/shakemap/data/transfer.conf
+++ b/shakemap/data/transfer.conf
@@ -59,6 +59,7 @@
 #---------------------------------------------------------------------------
 # - remote_host: The network name of your remote server (i.e., myhost.mydomain.org)
 # - remote_user (optional): user name on the remote server (default=same as local user)
+# - remote_port (optional): port number on the remote server (default=22)
 # - remote_directory: The directory on the remote server to which ShakeMap products
 #                     should be copied. ShakeMap will append the event ID to this
 #                     directory path, and place products in that new directory.

--- a/shakemap/data/transferspec.conf
+++ b/shakemap/data/transferspec.conf
@@ -12,6 +12,7 @@
   [[__many__]]
     remote_host = string()
     remote_user = string(min=0)
+    remote_port = integer(min=0)
     remote_directory = string()
     private_key = string()
 

--- a/shakemap/data/transferspec.conf
+++ b/shakemap/data/transferspec.conf
@@ -12,7 +12,7 @@
   [[__many__]]
     remote_host = string()
     remote_user = string(min=0)
-    remote_port = integer(min=0)
+    remote_port = integer(default=22)
     remote_directory = string()
     private_key = string()
 


### PR DESCRIPTION
I have updated the configuration source to work with the impactutils updates allowing operators to supply a remote port destination for the transfer_scp module.