### PR TITLE
Adding process_canceled option to shake 

### DIFF
--- a/bin/shake
+++ b/bin/shake
@@ -209,9 +209,12 @@ def main(args):
     event_path = os.path.join(data_path, args.eventid, 'current')
     cancel_file = os.path.join(event_path, CANCEL_FILE)
     if os.path.isfile(cancel_file):
-        logger.error(
-            'Event %s has been canceled: aborting run' % args.eventid)
-        return
+        if _config_['process_canceled']:
+            os.remove(cancel_file)
+        else:
+            logger.error(
+                'Event %s has been canceled: aborting run' % args.eventid)
+            return
 
     #
     # Build the database of commands, targets, and dependencies

--- a/shakemap/data/shake.conf
+++ b/shakemap/data/shake.conf
@@ -31,4 +31,10 @@ coremods = shakemap.coremods,
 # --cancel option will be passed onto these other modules.
 #
 #   cancel_modules = module1 --cancel module2 --cancel
+
+#
+# process_canceled: If this option is set to True, previously 
+# canceled events will be processed upon subsequent executions
+#
+#   process_canceled = True
 #

--- a/shakemap/data/shakespec.conf
+++ b/shakemap/data/shakespec.conf
@@ -1,3 +1,4 @@
 coremods = force_list(min=1)
 autorun_modules = string(default='')
 cancel_modules = string(default='')
+process_cancel = boolean(default=False)

--- a/shakemap/data/shakespec.conf
+++ b/shakemap/data/shakespec.conf
@@ -1,4 +1,4 @@
 coremods = force_list(min=1)
 autorun_modules = string(default='')
 cancel_modules = string(default='')
-process_cancel = boolean(default=False)
+process_canceled = boolean(default=False)


### PR DESCRIPTION
I am adding a new config option called process_canceled to the shake script which will allow operators to process previously canceled events in an automated fashion.  If this option is enabled in the shake.conf, then a previously canceled event will be processed by Shakemap by a quick remove of the "CANCELED" file from the event directory, and then continuing on with the processing.

Default for this parameter has been set to False within the shakespec.conf, so current users/operators do not have to add this option at all if they wish to run Shakemap v4 as usual with manual intervention still necessary to process a previously canceled event.