### PR TITLE
Fix precision of value in skimage shape contours

### DIFF
--- a/shakemap/coremods/shape.py
+++ b/shakemap/coremods/shape.py
@@ -126,7 +126,7 @@ def create_polygons(container, datadir, logger, max_workers, method='pcontour'):
                                              ('PARAMVALUE', 'float:14.4')]),
                   'geometry': 'Polygon'}
     elif method == 'skimage':
-        schema = {'properties': OrderedDict([('value', 'float:2.1'),
+        schema = {'properties': OrderedDict([('value', 'float:14.4'),
                                              ('units', 'str'),
                                              ('color', 'str'),
                                              ('weight', 'float:13.3')]),


### PR DESCRIPTION
When using the `skimage` method for producing shapefile contours, the `value` attribute attached to these contours was being rounded to the nearest integer, despite the precision being set to `float:2.1`. Clearly this means I don't understand exactly what fiona's precision strings mean; but I've modified it to match the `pcontour` schema and this fixes the unwanted rounding.