### PR TITLE
Extent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -169,7 +169,7 @@ package_list=(
       "ipython==7.29"
       "libcomcat>=2.0.12"
       "lockfile>=0.12.2"
-      "mapio==0.7.25"
+      "mapio>0.7.27"
       "matplotlib-base>=3.4.2"
       "numpy=1.21"
       "obspy>=1.2.2"

--- a/install.sh
+++ b/install.sh
@@ -21,9 +21,9 @@ source $prof
 # Name of virtual environment
 VENV=shakemap
 
-developer=0
+developer=1
 openquake_deps=0
-py_ver=3.9
+py_ver=3.8
 while getopts p:d:q FLAG; do
   case $FLAG in
     p)
@@ -135,7 +135,7 @@ conda clean -y --all
 
 # Extra packages to install with dev option
 dev_list=(
-    "autopep8>=1.5.7"
+    "black>=22.1.0"
     "flake8>=3.9.2"
     "pyflakes>=2.3.1"
     "rope>=0.19.0"
@@ -169,7 +169,7 @@ package_list=(
       "ipython==7.29"
       "libcomcat>=2.0.12"
       "lockfile>=0.12.2"
-      "mapio>0.7.27"
+      "mapio==0.7.25"
       "matplotlib-base>=3.4.2"
       "numpy=1.21"
       "obspy>=1.2.2"

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ VENV=shakemap
 
 developer=0
 openquake_deps=0
-py_ver=3.10
+py_ver=3.9
 while getopts p:d:q FLAG; do
   case $FLAG in
     p)

--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ package_list=(
       "gdal>=3.0.2"
       "h5py>=2.10.0"
       "impactutils>=0.8.28"
-      "ipython>=7.22.0"
+      "ipython==7.29"
       "libcomcat>=2.0.12"
       "lockfile>=0.12.2"
       "mapio>0.7.27"

--- a/shakelib/utils/utils.py
+++ b/shakelib/utils/utils.py
@@ -256,10 +256,8 @@ def _get_extent_from_multigmpe(rupture, config=None):
     d_min = config["extent"]["mmi"]["mindist"]
     d_max = config["extent"]["mmi"]["maxdist"]
     dx.rjb = np.logspace(np.log10(d_min), np.log10(d_max), size)
-    # Details don't matter for this; assuming vertical surface rupturing fault
-    # with epicenter at the surface.
-    dx.rrup = dx.rjb
-    dx.rhypo = dx.rjb
+    dx.rrup = np.sqrt(dx.rjb**2 + origin.depth**2)
+    dx.rhypo = dx.rrup
     dx.repi = dx.rjb
     dx.rx = np.zeros_like(dx.rjb)
     dx.ry0 = np.zeros_like(dx.rjb)

--- a/shakemap/coremods/model.py
+++ b/shakemap/coremods/model.py
@@ -1345,7 +1345,7 @@ class ModelModule(CoreModule):
             self.ccf.getCorrelation(t1_22, t2_22, matrix22)
             sta_phi_flat = sta_phi.flatten()
             make_sigma_matrix(matrix22, sta_phi_flat, sta_phi_flat)
-            np.fill_diagonal(matrix22, np.diag(matrix22) + sta_sig_extra ** 2)
+            np.fill_diagonal(matrix22, np.diag(matrix22) + sta_sig_extra**2)
             cov_WD_WD_inv = np.linalg.pinv(matrix22)
             #
             # Hold on to some things we'll need later
@@ -2108,7 +2108,7 @@ class ModelModule(CoreModule):
                 else:
                     mytau = sdf[key + "_tau"][six]
                 myphi = sdf[key + "_phi"][six]
-                mysigma = np.sqrt(mytau ** 2 + myphi ** 2)
+                mysigma = np.sqrt(mytau**2 + myphi**2)
                 mysigma_rock = sdf[key + "_sigma_rock"][six]
                 mysigma_soil = sdf[key + "_sigma_soil"][six]
                 imt_name = key.lower().replace("_pred", "")
@@ -2561,7 +2561,7 @@ class ModelModule(CoreModule):
             target_res = (
                 -(latspan + lonspan)
                 - np.sqrt(
-                    latspan ** 2 + lonspan ** 2 + 2 * latspan * lonspan * (2 * nmax - 1)
+                    latspan**2 + lonspan**2 + 2 * latspan * lonspan * (2 * nmax - 1)
                 )
             ) / (2 * (1 - nmax))
 

--- a/tests/shakelib/utils/utils_test.py
+++ b/tests/shakelib/utils/utils_test.py
@@ -83,10 +83,10 @@ def test_get_extent_small_complex():
     faultfile = os.path.join(datadir, "Hartzell11_fault.txt")
     rupture = get_rupture(origin, faultfile)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 95.28333333333333)
-    np.testing.assert_allclose(E, 115.1)
-    np.testing.assert_allclose(S, 23.083333333333332)
-    np.testing.assert_allclose(N, 39.75)
+    np.testing.assert_allclose(W, 95.299999999999997)
+    np.testing.assert_allclose(E, 115.08333333333333)
+    np.testing.assert_allclose(S, 23.100000000000001)
+    np.testing.assert_allclose(N, 39.733333333333334)
 
 
 def test_get_extent_bad_usage():
@@ -119,10 +119,10 @@ def test_get_extent_aspect():
     )
     rupture = get_rupture(origin, rrep)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 92.65)
-    np.testing.assert_allclose(E, 119.98333333333333)
+    np.testing.assert_allclose(W, 92.666666666666671)
+    np.testing.assert_allclose(E, 119.96666666666667)
     np.testing.assert_allclose(S, 19.833333333333332)
-    np.testing.assert_allclose(N, 38.96666666666667)
+    np.testing.assert_allclose(N, 38.950000000000003)
     #
     # Long vertical rupture
     #
@@ -137,8 +137,8 @@ def test_get_extent_aspect():
     )
     rupture = get_rupture(origin, rrep)
     W, E, S, N = get_extent(rupture)
-    np.testing.assert_allclose(W, 88.48333333333333)
-    np.testing.assert_allclose(E, 115.08333333333333)
+    np.testing.assert_allclose(W, 88.5)
+    np.testing.assert_allclose(E, 115.06666666666666)
     np.testing.assert_allclose(S, 16.1)
     np.testing.assert_allclose(N, 42.583333333333336)
 


### PR DESCRIPTION
- Partially addresses #1207, although this is untested because the result is unreproducible. For deep events the extent will be too large because Rrup was idiotically assumed to be Rjb. 
- Pins ipython version because ipyhon version 8 is broken. 
- Pins developer options to true because it is annoying to not have them.
- Pins to python version 3.8 even for non-linux because it fails otherwise.  
